### PR TITLE
dev: create issue templates for 'bug, 'feature request' & 'other'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Install the *cookiecutter-python* package with *python3 -m pip install cookiecutter-python*
+2. Run the **cli** as: *generate-python ...*
+   please provided the arguments supplied to the cli
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Linux Mint, iOS, Windows]
+ - Version [e.g. 1.2.0]
+   run: *generate-python --version*
+ - Python Interpreter
+   run: *generate-python --version*
+
+
+**Additional context**
+Add any other context about the problem here.
+For example, what input values were supplied to the *generate-python*
+cli (ie paste contents of your *config file*)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/issue-inquiry.md
+++ b/.github/ISSUE_TEMPLATE/issue-inquiry.md
@@ -1,0 +1,17 @@
+---
+name: Issue Inquiry
+about: Make an inquiry about an "issue" which is not a 'bug' nor a 'feature request'
+title: "[OTHER ISSUE]"
+labels: question
+assignees: ''
+
+---
+
+**TODO: Title Goes Here**
+
+**Do you have a question related to the *cookiecutter-python* package?**
+Please submit your question :)
+
+Examples:
+- Why is *A* designed the way it is designed?
+- How does *A* accomplish whatever it accomplishes?


### PR DESCRIPTION
Create issue template files, in markdown format (md), to assist in filing issues quicker on github. The md Issue Template files created, cover the cases for filing a 'bug report', a 'feature request' or 'other issues'. Previously, there were no Issue Templates and the user/developer would have to create all the Issue contents manually, leading to potentially inconsistently formatted and harder to classify Issues.