### PR TITLE
Cookiecutter Python Package v1.8.7 Release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,7 +73,7 @@ jobs:
         run: |
           # set the matrix strategy to Full Matrix Stress Test if on master/main or stress-test branch or any tag
           BRANCH_NAME=${GITHUB_REF_NAME}
-          if [[ $BRANCH_NAME == "master" || $BRANCH_NAME == "main" || $BRANCH_NAME == "stress-test" || $GITHUB_REF == refs/tags/* ]]; then
+          if [[ $BRANCH_NAME == "stress-test" || $GITHUB_REF == refs/tags/* ]]; then
             echo "matrix=$FULL_MATRIX_STRATEGY" >> $GITHUB_OUTPUT
           else
             echo "matrix=$UBUNTU_PY310_STRATEGY" >> $GITHUB_OUTPUT

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,21 @@
 Changelog
 =========
 
+1.8.7 (2023-12-16)
+==================
+
+Changes
+^^^^^^^
+
+ci
+""
+- run 1-Job Test, instead of Stress Tests, on push to master or main branch
+
+release
+"""""""
+- bump version to 1.8.7
+
+
 1.8.6 (2023-12-15)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -266,9 +266,9 @@ Free/Libre and Open Source Software (FLOSS)
 
 .. Github Releases & Tags
 
-.. |commits_since_specific_tag_on_master| image:: https://img.shields.io/github/commits-since/boromir674/cookiecutter-python-package/v1.8.6/master?color=blue&logo=github
+.. |commits_since_specific_tag_on_master| image:: https://img.shields.io/github/commits-since/boromir674/cookiecutter-python-package/v1.8.7/master?color=blue&logo=github
     :alt: GitHub commits since tagged version (branch)
-    :target: https://github.com/boromir674/cookiecutter-python-package/compare/v1.8.6..master
+    :target: https://github.com/boromir674/cookiecutter-python-package/compare/v1.8.7..master
 
 .. |commits_since_latest_github_release| image:: https://img.shields.io/github/commits-since/boromir674/cookiecutter-python-package/latest?color=blue&logo=semver&sort=semver
     :alt: GitHub commits since latest release (by SemVer)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ copyright = '2022, Konstantinos Lampridis'
 author = 'Konstantinos Lampridis'
 
 # The full version, including alpha/beta/rc tags
-release = '1.8.6'
+release = '1.8.7'
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "poetry.core.masonry.api"
 ## Also renders on pypi as 'subtitle'
 [tool.poetry]
 name = "cookiecutter_python"
-version = "1.8.6"
+version = "1.8.7"
 description = "Yet another modern Python Package (pypi) with emphasis in CI/CD and automation."
 authors = ["Konstantinos Lampridis <k.lampridis@hotmail.com>"]
 maintainers = ["Konstantinos Lampridis <k.lampridis@hotmail.com>"]

--- a/src/cookiecutter_python/__init__.py
+++ b/src/cookiecutter_python/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.8.6'
+__version__ = '1.8.7'
 
 from . import _logging  # noqa


### PR DESCRIPTION
1.8.7 (2023-12-16)
==================

Changes
-------

ci
""
- run 1-Job Test, instead of Stress Tests, on push to master or main branch

release
"""""""
- bump version to 1.8.7