### PR TITLE
Release v1.12.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,48 @@ Changelog
 =========
 
 
+1.12.0 (2024-01-18)
+===================
+
+In this release, we fix then [known issue](https://github.com/boromir674/cookiecutter-python-package/issues/63),
+when running the `Generator` CLI in `interactive` mode.
+
+**Now**, in case the CLI is ran in `interactive` mode, all interactive dialogs / prompts
+are delegated to `Questionnaire`, which is already a python dependency of the `Generator`.
+
+The `Cookiecutter` callable / executable is **now** always called, with the `no_input` boolean
+flag set to `True`.
+
+The idea was to refrain from updating our locked `cookiecutter` dependency, from 1.7.x to 2.x,  
+for the time being.
+
+
+Changes
+^^^^^^^
+
+feature
+"""""""
+- support running interactive CLI, without supplying User's Config Yaml file
+- populate Context, in pre_main, if interactive mode is ON
+
+test
+""""
+- make snapshot testinng robust against runtime Calendar Year changes!
+
+refactor
+""""""""
+- exclude DEBUG-level logs from being emitted in the Console (just in file)
+- Ruff, Black, Isort, Mypy
+
+chore
+"""""
+- remove Handler Chain Infra, since we delegate handling Input to Questionnaire
+
+release
+"""""""
+- bump version to 1.12.0
+
+
 1.11.4 (2023-12-25)
 ===================
 

--- a/README.rst
+++ b/README.rst
@@ -272,9 +272,9 @@ Free/Libre and Open Source Software (FLOSS)
 
 .. Github Releases & Tags
 
-.. |commits_since_specific_tag_on_master| image:: https://img.shields.io/github/commits-since/boromir674/cookiecutter-python-package/v1.11.4/master?color=blue&logo=github
+.. |commits_since_specific_tag_on_master| image:: https://img.shields.io/github/commits-since/boromir674/cookiecutter-python-package/v1.12.0/master?color=blue&logo=github
     :alt: GitHub commits since tagged version (branch)
-    :target: https://github.com/boromir674/cookiecutter-python-package/compare/v1.11.4..master
+    :target: https://github.com/boromir674/cookiecutter-python-package/compare/v1.12.0..master
 
 .. |commits_since_latest_github_release| image:: https://img.shields.io/github/commits-since/boromir674/cookiecutter-python-package/latest?color=blue&logo=semver&sort=semver
     :alt: GitHub commits since latest release (by SemVer)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ copyright = '2022, Konstantinos Lampridis'
 author = 'Konstantinos Lampridis'
 
 # The full version, including alpha/beta/rc tags
-release = '1.11.4'
+release = '1.12.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1431,14 +1431,14 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "wcwidth"
-version = "0.2.12"
+version = "0.2.13"
 description = "Measures the displayed width of unicode strings in a terminal"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "wcwidth-0.2.12-py2.py3-none-any.whl", hash = "sha256:f26ec43d96c8cbfed76a5075dac87680124fa84e0855195a6184da9c187f133c"},
-    {file = "wcwidth-0.2.12.tar.gz", hash = "sha256:f01c104efdf57971bcb756f054dd58ddec5204dd15fa31d6503ea57947d97c02"},
+    {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
+    {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "poetry.core.masonry.api"
 ## Also renders on pypi as 'subtitle'
 [tool.poetry]
 name = "cookiecutter_python"
-version = "1.12.0"
+version = "1.12.0-rc"
 description = "1-click Generator of Python Project, from Template with streamlined \"DevOps\" using a powerful CI/CD Pipeline."
 authors = ["Konstantinos Lampridis <k.lampridis@hotmail.com>"]
 maintainers = ["Konstantinos Lampridis <k.lampridis@hotmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "poetry.core.masonry.api"
 ## Also renders on pypi as 'subtitle'
 [tool.poetry]
 name = "cookiecutter_python"
-version = "1.11.4"
+version = "1.12.0"
 description = "1-click Generator of Python Project, from Template with streamlined \"DevOps\" using a powerful CI/CD Pipeline."
 authors = ["Konstantinos Lampridis <k.lampridis@hotmail.com>"]
 maintainers = ["Konstantinos Lampridis <k.lampridis@hotmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "poetry.core.masonry.api"
 ## Also renders on pypi as 'subtitle'
 [tool.poetry]
 name = "cookiecutter_python"
-version = "1.12.0-rc"
+version = "1.12.0"
 description = "1-click Generator of Python Project, from Template with streamlined \"DevOps\" using a powerful CI/CD Pipeline."
 authors = ["Konstantinos Lampridis <k.lampridis@hotmail.com>"]
 maintainers = ["Konstantinos Lampridis <k.lampridis@hotmail.com>"]

--- a/src/cookiecutter_python/__init__.py
+++ b/src/cookiecutter_python/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.11.4'
+__version__ = '1.12.0'
 
 from . import _logging  # noqa

--- a/src/cookiecutter_python/__init__.py
+++ b/src/cookiecutter_python/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.12.0'
+__version__ = '1.12.0-rc'
 
 from . import _logging  # noqa

--- a/src/cookiecutter_python/__init__.py
+++ b/src/cookiecutter_python/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.12.0-rc'
+__version__ = '1.12.0'
 
 from . import _logging  # noqa

--- a/src/cookiecutter_python/_logging.py
+++ b/src/cookiecutter_python/_logging.py
@@ -58,8 +58,8 @@ console = logging.StreamHandler()
 
 
 ### Handler which writes DEBUG messages or higher to the sys.stderr ###
-console.setLevel(logging.DEBUG)
-# console.setLevel(logging.INFO)
+# console.setLevel(logging.DEBUG)
+console.setLevel(logging.INFO)
 
 
 # set a format which is simpler for console use

--- a/src/cookiecutter_python/backend/helpers.py
+++ b/src/cookiecutter_python/backend/helpers.py
@@ -1,34 +1,97 @@
+import json
 import logging
 import typing as t
-
-from cookiecutter_python.handle.interpreters_support import handle as get_interpreters
-
-from .load_config import get_interpreters_from_yaml
 
 GivenInterpreters = t.Mapping[str, t.Sequence[str]]
 
 logger = logging.getLogger(__name__)
 
 
-def supported_interpreters(config_file: str, no_input: bool) -> t.Optional[GivenInterpreters]:
-    # Interactive Mode: ask for user input with Interactive (console) Dialog
-    if not no_input:  # render checkbox console ui, and return user selection
-        # TODO: verify that the below works!
-        return check_box_dialog(config_file=config_file)
-    # NON Interactive Mode: try to automatically read interpreters from config
-    if config_file:
-        # read 'default_context.interpreters' from User Config yaml file
-        return get_interpreters_from_yaml(config_file)
-    ## No User Config yaml file, was supplied through CLI parameters, at runtime
-    return None
+def parse_context(config_file: str):
+    # initialize data
+    user_context = {}
+    from pathlib import Path
 
+    my_dir = Path(__file__).parent.absolute()
 
-def check_box_dialog(config_file: t.Optional[str] = None) -> GivenInterpreters:
-    defaults: t.Optional[t.Sequence[str]] = None
+    # use whatever way cookiecutter uses to render the cookiecutter.json
+    # cookie uses Jinja2
+
+    from jinja2 import Environment, FileSystemLoader
+
+    # render file
+    env = Environment(
+        loader=FileSystemLoader(str(my_dir / '..')),
+        extensions=['jinja2_time.TimeExtension'],  # shipped with cookiecutter 1.7
+    )
+    template = env.get_template('cookiecutter.json')
+    rendered = template.render({'cookiecutter': {}})
+
+    assert isinstance(rendered, str)
+
+    cook_json: t.Mapping[str, t.Any] = json.loads(rendered)
+
+    # in cookiecutter 1.7, a 'choice' variable is a json array
+    choices = {k: v for k, v in cook_json.items() if isinstance(v, list)}
+    assert 'rtd_python_version' in choices, f"KEYS: {choices.keys()}"
+    choice_defaults = {k: v[0] for k, v in choices.items()}
+
+    # start
+    c = cook_json['interpreters']
+
+    cookie_defaults = dict(cook_json, **choice_defaults)
+
     if config_file:
-        interpreters_data: t.Optional[GivenInterpreters] = get_interpreters_from_yaml(
-            config_file
-        )
-        if interpreters_data:
-            defaults = interpreters_data.get('supported-interpreters', None)
-    return get_interpreters(choices=defaults)
+        from .user_config_proxy import get_user_config
+
+        data = get_user_config(config_file, default_config=False)
+        # data = load_yaml(config_file)
+        user_context = data['default_context']
+        c = json.loads(user_context.get('interpreters', '{}'))
+
+    context_defaults = dict(cookie_defaults, **user_context)
+
+    from cookiecutter_python.handle.interactive_cli_pipeline import (
+        InteractiveDialogsPipeline,
+    )
+
+    pipe = InteractiveDialogsPipeline()
+
+    # c = json.loads(context_defaults.get('interpreters', '{}'))
+    cc = c.get('supported-interpreters', ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"])
+    # assert choices['rtd_python_version'] == [], f"DEBUG: {choices['rtd_python_version']}"
+    res = pipe.process(
+        [
+            {
+                "project_name": context_defaults['project_name'],
+                "project_type": {
+                    'default': context_defaults['project_type'],
+                    'choices': choices['project_type'],
+                },
+                "full_name": context_defaults['full_name'],
+                "author_email": context_defaults['author_email'],
+                "github_username": context_defaults['github_username'],
+                "project_short_description": context_defaults['project_short_description'],
+                # "release_date": context_defaults['release_date'],
+                # "year": context_defaults['year'],
+                "version": context_defaults['version'],
+                "initialize_git_repo": {
+                    'default': context_defaults['initialize_git_repo'],
+                    'choices': choices['initialize_git_repo'],
+                },
+                "supported-interpreters": {
+                    # 'default': context_defaults['initialize_git_repo'],
+                    'choices': [(choice, True) for choice in cc],
+                },
+                "docs_builder": {
+                    'default': context_defaults['docs_builder'],
+                    'choices': choices['docs_builder'],
+                },
+                "rtd_python_version": {
+                    'default': context_defaults['rtd_python_version'],
+                    'choices': choices['rtd_python_version'],
+                },
+            }
+        ]
+    )
+    return res

--- a/src/cookiecutter_python/backend/hosting_services/check_engine.py
+++ b/src/cookiecutter_python/backend/hosting_services/check_engine.py
@@ -53,7 +53,28 @@ class Engine:
         return iter(filter(None, [getattr(self, server)() for server in servers]))
 
     @staticmethod
-    def create(config_file, default_config):
+    def create(config_file: str, default_config: bool):
+        """Initialize objects, for Asynchronous http with 3rd-party Services
+
+        Objects are designed to Ask PyPI and Read The Docs, if the soon to be
+        generated package name, and readthedocs project slug are available.
+
+        These 'Checker' objects make asynchronous http requests to PyPI and RTD
+        web servers, for non-blocking IO, and to avoid blocking the main thread.
+
+        Checkers are initialized as 'Activated' if User Config is given and
+        Default Config is False.
+
+        Then each Checker (pypi, rtd) requires:
+        - PyPI requires the 'pkg_name' in User's yaml Config
+        - RTD requires the 'readthedocs_project_slug' in User's yaml Config
+
+        to derive the URLs for Future Requests
+
+        Args:
+            config_file (str): user's yaml config file
+            default_config (bool): default config flag
+        """
         return Engine(
             config_file,
             default_config,

--- a/src/cookiecutter_python/backend/main.py
+++ b/src/cookiecutter_python/backend/main.py
@@ -15,17 +15,20 @@ WEB_SERVERS = ['pypi', 'readthedocs']
 
 
 def generate(
-    checkout=None,
-    no_input=False,
+    # interactive=True,
+    no_input=False,  # INTERACTIVE ON by Default
     extra_context=None,
     replay=False,
     overwrite=False,
     output_dir='.',
     config_file=None,
+    skip_if_file_exists=False,
+    # deprecated
     default_config=False,
     password=None,
     directory=None,
-    skip_if_file_exists=False,
+    checkout=None,
+    ###
 ) -> str:
     """Create Python Project, with CI/CD pipeline, from the project template.
 
@@ -39,7 +42,6 @@ def generate(
     #       -  prompt for user input in interactive or atempt to read from yaml otherwise
     #  - prepare Cookiecutter extra context:
     #      - add interpreters versions list
-    #      - store 'docs' folder, per docs builder, that Generator supports
     request = pre_main(
         Request(
             config_file=config_file,
@@ -54,7 +56,8 @@ def generate(
     project_dir = generator(
         os.path.abspath(os.path.join(my_dir, '..')),  # template dir path
         checkout=checkout,
-        no_input=no_input,
+        # no_input=no_input,
+        no_input=True,
         # we pass the Request computed context in the Cookiecutter Extra Context
         # if extra_context includes a 'supported-interpreters' key:
         #  no_input == True: automatic generation of CI Test Matrix Python Interpreters versions list, should happen

--- a/src/cookiecutter_python/backend/pre_main.py
+++ b/src/cookiecutter_python/backend/pre_main.py
@@ -1,6 +1,6 @@
 import typing as t
 
-from .helpers import supported_interpreters
+from .helpers import parse_context
 from .hosting_services import Engine
 
 
@@ -21,10 +21,6 @@ def pre_main(request):
 
     # Start Requesting Futures! - Hosting Service: PyPI, Read The Docs
     request.check_results = request.check.check(request.web_servers)
-    # Skipped i:
-    # - User Config does not have pkg_name and, readthedocs_project_slug
-    #   which are used to rderive the URLs for Future Requests
-    # - checker property activate_flag is False
     """
     If skipped due to missing info in User Config, we can expect Logs roughly as:
     logger.info(
@@ -32,23 +28,32 @@ def pre_main(request):
     )
     logger.info(error)
     """
+    _context = request.extra_context or {}
+    interactive_mode = not bool(request.no_input)
 
-    # Case 1: NON Interactive Mode <--> `request.no_input == True`
-    #   - if interpreters is None, then no user config file supplied in CLI
-    # Case 2: Interactive Mode <--> `request.no_input == False`
-    #   - always meaningful value, since Interactive Dialog ensures that
-    interpreters: t.Optional[t.Mapping[str, t.Sequence[str]]] = supported_interpreters(
-        request.config_file, request.no_input
-    )
-    # if None, then we are in NON interactive mode, but no User Config, passed in CLI
-
-    if interpreters:  # update cookiecutter extra_context
-        # supported interpreters supplied either from yaml or from user's input
-        request.extra_context = dict(
-            request.extra_context or {},
-            **{
-                'interpreters': interpreters,
+    # If INTERACTIVE, Run Dialog Pipeline, to update Context
+    if interactive_mode:
+        user_input = parse_context(request.config_file)
+        _context.update(
+            {
+                'interpreters': {
+                    'supported-interpreters': user_input.pop('supported-interpreters')
+                },  # 'supported-interpreters
+                # 'supported-interpreters': user_input.pop('supported-interpreters'),
+                **user_input,
             }
         )
 
+    else:
+        if request.config_file:
+            # just update interpreters cookiecutter extra_context
+            from .load_config import get_interpreters_from_yaml
+
+            interpreters: t.Mapping[str, t.Sequence[str]] = get_interpreters_from_yaml(
+                request.config_file
+            )
+            if interpreters:
+                _context['interpreters'] = interpreters
+
+    request.extra_context = dict(_context)
     return request

--- a/src/cookiecutter_python/cli.py
+++ b/src/cookiecutter_python/cli.py
@@ -91,8 +91,8 @@ def main(
     # TODO Improvement: add logging configuration
     try:
         project: str = generate(
-            checkout,
-            no_input,
+            checkout=checkout,
+            no_input=no_input,
             replay=replay,
             overwrite=overwrite,
             output_dir=output_dir,

--- a/src/cookiecutter_python/handle/dialogs/dialog.py
+++ b/src/cookiecutter_python/handle/dialogs/dialog.py
@@ -14,5 +14,4 @@ class DialogRegistry(SubclassRegistry[Dialog]):
 
 
 class InteractiveDialog(metaclass=DialogRegistry):
-    def dialog(self, *args, **kwargs):
-        raise NotImplementedError
+    pass

--- a/src/cookiecutter_python/handle/dialogs/lib/project_name.py
+++ b/src/cookiecutter_python/handle/dialogs/lib/project_name.py
@@ -1,0 +1,162 @@
+import datetime
+from typing import Mapping
+
+from questionary import Choice, prompt
+
+from ..dialog import InteractiveDialog
+
+
+@InteractiveDialog.register_as_subclass('project-name')
+class ProjectNameDialog:
+    def dialog(self, cookie_vars) -> Mapping[str, str]:
+        print(f"\n\n---- {cookie_vars['rtd_python_version']}")
+        return prompt(
+            [
+                {
+                    'type': 'input',
+                    'name': 'project_name',
+                    'message': 'Enter the Project Name (ie human-readable text):',
+                    'default': cookie_vars['project_name'],
+                },
+                {
+                    'type': 'select',
+                    'name': 'project_type',
+                    'message': 'Select the Project Type:',
+                    'choices': cookie_vars['project_type']['choices'],
+                    'default': cookie_vars['project_type']['default'],
+                },
+                {
+                    'type': 'input',
+                    'name': 'project_slug',
+                    'message': 'Enter the Project Slug (ie lowercase text, no spaces):',
+                    'default': lambda answers: answers['project_name']
+                    .lower()
+                    .replace(' ', '-'),
+                },
+                {
+                    'type': 'input',
+                    'name': 'pkg_name',
+                    'message': 'Enter the Package Name (ie lowercase text, no spaces):',
+                    'default': lambda answers: answers['project_slug'].replace('-', '_'),
+                },
+                {
+                    'type': 'input',
+                    'name': 'repo_name',
+                    'message': 'Enter the Repository Name (ie lowercase text, no spaces):',
+                    'default': lambda answers: answers['project_slug'],
+                },
+                {
+                    'type': 'input',
+                    'name': 'readthedocs_project_slug',
+                    'message': 'Enter the ReadTheDocs Project Slug (ie lowercase text, no spaces):',
+                    'default': lambda answers: answers['project_slug'],
+                },
+                {
+                    'type': 'input',
+                    'name': 'docker_image',
+                    'message': 'Enter the Docker Image Name (ie lowercase text, no spaces):',
+                    'default': lambda answers: answers['project_slug'],
+                },
+                # full_name
+                {
+                    'type': 'input',
+                    'name': 'full_name',
+                    'message': 'Enter full_name:',
+                    'default': cookie_vars['full_name'],
+                },
+                # author
+                {
+                    'type': 'input',
+                    'name': 'author',
+                    'message': 'Enter author:',
+                    'default': lambda answers: answers['full_name'],
+                },
+                # author_email
+                {
+                    'type': 'input',
+                    'name': 'author_email',
+                    'message': 'Enter author_email:',
+                    'default': cookie_vars['author_email'],
+                },
+                # github_username
+                {
+                    'type': 'input',
+                    'name': 'github_username',
+                    'message': 'Enter github_username:',
+                    'default': cookie_vars['github_username'],
+                },
+                # project_short_description
+                {
+                    'type': 'input',
+                    'name': 'project_short_description',
+                    'message': 'Enter project_short_description:',
+                    'default': cookie_vars['project_short_description'],
+                },
+                # pypi_subtitle
+                {
+                    'type': 'input',
+                    'name': 'pypi_subtitle',
+                    'message': 'Enter pypi_subtitle:',
+                    'default': lambda answers: answers['project_short_description'],
+                },
+                # release_date
+                {
+                    'type': 'input',
+                    'name': 'release_date',
+                    'message': 'Enter release_date:',
+                    # Default is NOW
+                    'default': datetime.datetime.now().strftime('%Y-%m-%d'),
+                },
+                # year
+                {
+                    'type': 'input',
+                    'name': 'year',
+                    'message': 'Enter year:',
+                    # Default is NOW
+                    'default': datetime.datetime.now().strftime('%Y'),
+                },
+                # version
+                {
+                    'type': 'input',
+                    'name': 'version',
+                    'message': 'Enter version:',
+                    'default': cookie_vars['version'],
+                },
+                # initialize_git_repo
+                {
+                    'type': 'select',
+                    'name': 'initialize_git_repo',
+                    'message': 'Initialize Git Repository?',
+                    'choices': cookie_vars['initialize_git_repo']['choices'],
+                    'default': cookie_vars['initialize_git_repo']['default'],
+                },
+                # interpreters
+                {
+                    'type': 'checkbox',
+                    'name': 'supported-interpreters',
+                    'message': 'Select the python Interpreters you wish to support',
+                    'choices': [
+                        Choice(str(x[0]), checked=bool(x[1]))
+                        for x in cookie_vars['supported-interpreters']['choices']
+                    ]
+                    # 'default': ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11'],
+                },
+                # docs_builder
+                {
+                    'type': 'select',
+                    'name': 'docs_builder',
+                    'message': 'Select the docs builder you wish to use',
+                    'choices': cookie_vars['docs_builder']['choices'],
+                    'default': cookie_vars['docs_builder']['default'],
+                },
+                # rtd_python_version
+                {
+                    'type': 'select',
+                    'name': 'rtd_python_version',
+                    'message': 'Select the python version you wish to use for ReadTheDocs',
+                    # 'choices': ['3.8', '3.9', '3.10', '3.11', '3.12'],
+                    'choices': cookie_vars['rtd_python_version']['choices'],
+                    'default': cookie_vars['rtd_python_version']['default'],
+                },
+            ]
+        )

--- a/src/cookiecutter_python/handle/interactive_cli_pipeline.py
+++ b/src/cookiecutter_python/handle/interactive_cli_pipeline.py
@@ -1,0 +1,36 @@
+"""Handles sequence of Interactive User Dialogs, for Context Information."""
+
+from .node_factory import NodeFactory
+
+
+class InteractiveDialogsPipeline:
+    """Handles sequence of Interactive User Dialogs, for Context Information."""
+
+    dialogs = [
+        'project-name',
+        # 'project_type',
+        # 'project_slug',
+        # 'pkg_name',
+        # 'repo_name',
+        # 'readthedocs_project_slug',
+        # 'docker_image',
+        # 'full_name',
+        # 'author',
+        # 'author_email',
+        # 'github_username',
+        # 'project_short_description',
+        # 'pypi_subtitle',
+        # 'release_date',
+        # 'year',
+        # 'version',
+        # 'initialize_git_repo',
+        # 'interpreters',
+        # 'docs_builder',
+        # 'rtd_python_version',
+    ]
+
+    def process(self, request):
+        """Process sequence of Interactive User Dialogs, for Context Information."""
+        for dialog in self.dialogs:
+            request = NodeFactory.create(dialog).process(request)
+        return request

--- a/src/cookiecutter_python/handle/node_base.py
+++ b/src/cookiecutter_python/handle/node_base.py
@@ -1,0 +1,14 @@
+import typing as t
+
+from .node_interface import Node
+
+
+class DialogNode(Node[t.List, t.Mapping[str, t.Any]]):
+    """Handles a single Interactive User Dialog, for Context Information."""
+
+    def __init__(self, dialog):
+        self.ela = dialog
+
+    def process(self, request):
+        """Process a single Interactive User Dialog, for Context Information."""
+        return self.ela.dialog(*request)

--- a/src/cookiecutter_python/handle/node_factory.py
+++ b/src/cookiecutter_python/handle/node_factory.py
@@ -1,0 +1,12 @@
+from .dialogs import InteractiveDialog
+from .node_base import DialogNode
+
+
+class NodeFactory:
+    @staticmethod
+    def create(dialog_name: str):
+        return DialogNode(
+            InteractiveDialog.create(
+                dialog_name,
+            )
+        )

--- a/src/cookiecutter_python/handle/node_interface.py
+++ b/src/cookiecutter_python/handle/node_interface.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+from typing import Generic, Optional, TypeVar
+
+T = TypeVar('T')
+TT = TypeVar('TT')
+
+
+class Node(ABC, Generic[T, TT]):
+    @abstractmethod
+    def process(self, request: T) -> Optional[TT]:
+        raise NotImplementedError

--- a/src/cookiecutter_python/hooks/pre_gen_project.py
+++ b/src/cookiecutter_python/hooks/pre_gen_project.py
@@ -17,6 +17,8 @@ def get_request():
     cookiecutter = OrderedDict()
     cookiecutter: OrderedDict = {{cookiecutter}}
 
+    logger.info("Cookiecutter Data: %s", json.dumps(cookiecutter, sort_keys=True, indent=4))
+
     interpreters = cookiecutter['interpreters']
     if isinstance(interpreters, str):  # we assume it is json
         interpreters = json.loads(interpreters)

--- a/tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py
+++ b/tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py
@@ -55,6 +55,14 @@ def test_snapshot_matches_runtime(snapshot, biskotaki_ci_project, test_root):
         [x for x in runtime_relative_paths_set if '__pycache__' not in x.parts]
     )
 
+    # EXCLUDE from test .pytest_cache/ folders too
+    snap_relative_paths_set = set(
+        [x for x in snap_relative_paths_set if '.pytest_cache' not in x.parts]
+    )
+    runtime_relative_paths_set = set(
+        [x for x in runtime_relative_paths_set if '.pytest_cache' not in x.parts]
+    )
+
     # WHEN we compare the 2 sets of relative Paths
 
     ## THEN, the sets should be the same
@@ -69,10 +77,10 @@ def test_snapshot_matches_runtime(snapshot, biskotaki_ci_project, test_root):
         os.environ.get("BUG_LOG_DEL_WIN") != "permission_error"
     )
 
-    # we should implement a if run on CI check here
-    running_on_ci: bool = 'CI' in os.environ
+    # if running on CI
+    RUNNING_ON_CI: bool = 'CI' in os.environ
 
-    if not running_on_ci:
+    if not RUNNING_ON_CI:
         # just exclude pre-emptively '.vscode/' folder, and '.vscode/settings.json' file
         # also exclude .tox/ folder, and .tox/ folder contents
         snap_relative_paths_set = set(
@@ -113,42 +121,102 @@ def test_snapshot_matches_runtime(snapshot, biskotaki_ci_project, test_root):
     # comparing rolling date with the static one in the snapshot
 
     # first compare CHANGLOG files, then all other files
-    snapshot_changelog = snapshot_dir / 'CHANGELOG.rst'  # the expectation
     runtime_changelog = runtime_biskotaki / 'CHANGELOG.rst'  # the reality
+    snapshot_changelog = snapshot_dir / 'CHANGELOG.rst'  # the expectation
 
-    snap_file_content = snapshot_changelog.read_text().splitlines()
     runtime_file_content = runtime_changelog.read_text().splitlines()
-    assert len(snap_file_content) == len(runtime_file_content)
-    assert all(
+    snap_file_content = snapshot_changelog.read_text().splitlines()
+    assert len(runtime_file_content) == len(snap_file_content)
+
+    line_pairs_generator = iter(
         [
-            line_pair[0] == line_pair[1]
+            line_pair
             for line_pair in [
                 x
-                for x in zip(snap_file_content, runtime_file_content)
+                for x in zip(runtime_file_content, snap_file_content)
                 if not x[0].startswith('0.0.1')
             ]
         ]
-    ), (
-        f"File: CHANGELOG.rst has different content in Snapshot and Runtime\n"
-        "-------------------\n"
-        f"Snapshot: {snapshot_changelog}\n"
-        "-------------------\n"
-        f"Runtime: {runtime_changelog}\n"
-        "-------------------\n"
     )
 
+    if RUNNING_ON_CI:  # quickly do sanity check
+        assert all([line_pair[0] == line_pair[1] for line_pair in line_pairs_generator]), (
+            f"File: CHANGELOG.rst has different content at Runtime vs Snapshot\n"
+            "-------------------\n"
+            f"Runtime: {runtime_changelog}\n"
+            "-------------------\n"
+            f"Snapshot: {snapshot_changelog}\n"
+            "-------------------\n"
+        )
+    else:  # sanity check indicating the exact failling line in case of error
+        for line_pair in line_pairs_generator:
+            assert line_pair[0] == line_pair[1], (
+                f"File: CHANGELOG.rst has different content at Runtime vs Snapshot\n"
+                "-------------------\n"
+                f"Runtime: {runtime_changelog}\n"
+                "-------------------\n"
+                f"Snapshot: {snapshot_changelog}\n"
+                "-------------------\n"
+                f"Line: {line_pair[0]}\n"
+                "-------------------\n"
+            )
+
+    # Remove CHANGELOG.rst from Automatic Comparison
     automated_files = snap_relative_paths_set - {Path('CHANGELOG.rst')}
 
-    for relative_path in sorted([x for x in automated_files if x.is_file()]):
-        snap_file = snapshot_dir / relative_path
-        runtime_file = runtime_biskotaki / relative_path
+    # THEN Compare docs/conf.py to disregard Calendar Year of Snapshot Creation vs Runtime
+    runtime_conf = runtime_biskotaki / 'docs' / 'conf.py'  # the reality
+    snapshot_conf = snapshot_dir / 'docs' / 'conf.py'  # the expectation
 
-        assert snap_file.read_text() == runtime_file.read_text(), (
-            f"File: {relative_path} has different content in Snapshot and Runtime\n"
+    runtime_file_content = runtime_conf.read_text().splitlines()
+    snap_file_content = snapshot_conf.read_text().splitlines()
+
+    assert len(runtime_file_content) == len(snap_file_content)
+    line_pairs_generator = iter(
+        line_pair
+        for line_pair in [
+            x
+            for x in zip(runtime_file_content, snap_file_content)
+            if not (x[1].startswith('release =') or 'year=' in x[1])
+        ]
+    )
+    if RUNNING_ON_CI:  # quickly do sanity check
+        assert all([line_pair[0] == line_pair[1] for line_pair in line_pairs_generator]), (
+            f"File: docs/conf.py has different content at Runtime vs Snapshot\n"
             "-------------------\n"
-            f"Snapshot: {snap_file}\n"
+            f"Runtime: {runtime_conf}\n"
+            "-------------------\n"
+            f"Snapshot: {snapshot_conf}\n"
+            "-------------------\n"
+        )
+    else:  # sanity check indicating the exact failling line in case of error
+        for line_pair in line_pairs_generator:
+            assert line_pair[0] == line_pair[1], (
+                f"File: docs/conf.py has different content at Runtime vs Snapshot\n"
+                "-------------------\n"
+                f"Runtime: {runtime_conf}\n"
+                "-------------------\n"
+                f"Snapshot: {snapshot_conf}\n"
+                "-------------------\n"
+                f"Line: {line_pair[0]}\n"
+                "-------------------\n"
+            )
+
+    # Remove docs/conf.py from Automatic Comparison
+    automated_files = automated_files - {Path('docs/conf.py')}
+
+    ## AUTOMATIC Snapshot COMPARISON ##
+
+    for relative_path in sorted([x for x in automated_files if x.is_file()]):
+        runtime_file = runtime_biskotaki / relative_path
+        snap_file = snapshot_dir / relative_path
+
+        assert runtime_file.read_text() == snap_file.read_text(), (
+            f"File: {relative_path} has different content at Runtime vs Snapshot\n"
             "-------------------\n"
             f"Runtime: {runtime_file}\n"
+            "-------------------\n"
+            f"Snapshot: {snap_file}\n"
             "-------------------\n"
         )
 


### PR DESCRIPTION
In this release, we fix then [known issue](https://github.com/boromir674/cookiecutter-python-package/issues/63),
when running the `Generator` CLI in `interactive` mode.

**Now**, in case the CLI is ran in `interactive` mode, all interactive dialogs / prompts
are delegated to `Questionnaire`, which is already a python dependency of the `Generator`.

The `Cookiecutter` callable / executable is **now** always called, with the `no_input` boolean
flag set to `True`.

The idea was to refrain from updating our locked `cookiecutter` dependency, from 1.7.x to 2.x,  
for the time being.