### PR TITLE
release

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -119,3 +119,28 @@ jobs:
           destination-repository-username: 'boromir674'
           target-branch: ${{ env.branch }}
           commit-message: 'apply Template from https://github.com/boromir674/cookiecutter-python-package'
+
+      ## GENERATE Python Gold Standard FROM TEMPLATE into gen/ ##
+      # ROOT : gen/biskotaki/pyproject.toml
+      - name: Generate Python Gold Standard Biskotaki from Template
+        env:
+          USER_CONFIG: tests/data/gold-standard.yml
+        run: |
+          echo "    version: \"${{ env.PKG_VERSION }}\"" >> ${{ env.USER_CONFIG }}
+          generate-python -o gen-gold --config-file "${{ env.USER_CONFIG }}" --no-input -f --offline
+
+      ## PUSH the Python Gold Standard to BISKOTAKI REPO ##
+      - name: Push to dedicated branch in biskotaki repo
+        # Pin to v1.7.2 -> 07c4d7b3def0a8ebe788a8f2c843a4e1de4f6900
+        uses: cpina/github-action-push-to-another-repository@07c4d7b3def0a8ebe788a8f2c843a4e1de4f6900
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_GITHUB_KEY }}
+        with:
+          source-directory: 'gen-gold/biskotaki-gold-standard'
+          destination-github-username: 'boromir674'
+          destination-repository-name: 'biskotaki'
+          user-email: k.lampridis@hotmail.com
+          user-name: 'Konstantinos'
+          destination-repository-username: 'boromir674'
+          target-branch: py-gold
+          commit-message: 'apply Template from https://github.com/boromir674/cookiecutter-python-package'

--- a/.github/workflows/policy_lint.yml
+++ b/.github/workflows/policy_lint.yml
@@ -57,7 +57,7 @@ on:
         # ie { "l": 10 } -> allowes at most 10 low, 0 m, and 0 h
         # ie { "l": 10, "m": 3 } -> allowes at most 10 low, 3 m, and 0 h
         # Default is 6 allowed low, 0 m, and 0 h
-        default: '{"l": 6, "m": 0, "h": 0}'
+        default: '{"l": 8, "m": 0, "h": 0}'
 
 jobs:
   # Decide whether to run Lint Job, given incoming Signal
@@ -205,7 +205,7 @@ jobs:
       - name: 'Parse Bandit Results, and prepare comparing LOW, MEDIUM, and HIGH'
         run: |
           # Parse Totals Object
-          TOTALS=$(jq '.runs[0].properties.metrics._totals' results-sarif.json)
+          TOTALS=$(jq '.runs[0].properties.metrics._totals' "${{ env._SARIF_FILE }}")
 
           # Find CWE's of HIGH Severity
           HIGH=$(echo $TOTALS | jq '.["SEVERITY.HIGH"]')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -425,5 +425,5 @@ jobs:
       tag: ${{ github.ref_name }}
       draft: ${{ needs.check_which_git_branch_we_are_on.outputs.ENVIRONMENT_NAME == 'TEST_DEPLOYMENT' }}
     secrets:
-      # passing the GH_TOKEN, will render in GH as ie: 'boromir674 released this yesterday', instead of 'github-actions released this yesterday'
+      # passing the GH_TOKEN PAT, to render in GH as ie: 'boromir674 released this yesterday', instead of 'github-actions released this yesterday'
       gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -425,5 +425,5 @@ jobs:
       tag: ${{ github.ref_name }}
       draft: ${{ needs.check_which_git_branch_we_are_on.outputs.ENVIRONMENT_NAME == 'TEST_DEPLOYMENT' }}
     secrets:
-      # passing the GH_TOKEN, attempting to produce a "verified" Release
+      # passing the GH_TOKEN, will render in GH as ie: 'boromir674 released this yesterday', instead of 'github-actions released this yesterday'
       gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -417,7 +417,7 @@ jobs:
 
 ### Make a Github Release ###
   gh_release:
-    needs: [test_suite, check_which_git_branch_we_are_on]
+    needs: [check_which_git_branch_we_are_on]
     if: ${{ needs.check_which_git_branch_we_are_on.outputs.AUTOMATED_DEPLOY == 'true' }}
     uses: boromir674/automated-workflows/.github/workflows/gh-release.yml@test
     name: 'GH Release'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -424,3 +424,5 @@ jobs:
     with:
       tag: ${{ github.ref_name }}
       draft: ${{ needs.check_which_git_branch_we_are_on.outputs.ENVIRONMENT_NAME == 'TEST_DEPLOYMENT' }}
+      # using the default token provided by GH: ${{ github.token }}, yilds unverified Releases
+      gh_token: ${{ github.token }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -425,4 +425,5 @@ jobs:
       tag: ${{ github.ref_name }}
       draft: ${{ needs.check_which_git_branch_we_are_on.outputs.ENVIRONMENT_NAME == 'TEST_DEPLOYMENT' }}
       # using the default token provided by GH: ${{ github.token }}, yilds unverified Releases
+    secrets:
       gh_token: ${{ github.token }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -316,7 +316,7 @@ jobs:
   check_which_git_branch_we_are_on:
     runs-on: ubuntu-latest
     needs: set_github_outputs
-    if: ${{ startsWith(github.event.ref, 'refs/tags/v') && needs.set_github_outputs.outputs.PUBLISH_ON_PYPI == 'true' }}
+    if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
     # Signals only if all below are True:
     #  - PyPI Job Switch is ON
     #  - Workflow Event is a 'v*' Tag (e.g. v1.0.0, v-test)
@@ -367,7 +367,7 @@ jobs:
     needs: [test_suite, check_which_git_branch_we_are_on]
     uses: boromir674/automated-workflows/.github/workflows/pypi_env.yml@8e97f596067fcbbaa0a6927ec1ee47dce4ab5f1a
     with:
-      should_trigger: ${{ needs.check_which_git_branch_we_are_on.outputs.AUTOMATED_DEPLOY == 'true' }}
+      should_trigger: ${{ needs.set_github_outputs.outputs.PUBLISH_ON_PYPI == 'true' && needs.check_which_git_branch_we_are_on.outputs.AUTOMATED_DEPLOY == 'true' }}
       distro_name: cookiecutter_python
       distro_version: ${{ needs.test_suite.outputs.PEP_VERSION }}
       pypi_env: '${{ needs.check_which_git_branch_we_are_on.outputs.ENVIRONMENT_NAME }}'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,12 +34,12 @@ env:
   TEST_STRATEGY: "{\"platform\": [\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"], \"python-version\":[\"3.10\"]}"
 
   ##### JOB ON/OFF SWITCHES - 1st level overrides #####
-  RUN_UNIT_TESTS: "true"
-  RUN_LINT_CHECKS: "true"
-  DOCKER_JOB_ON: "true"
-  PUBLISH_ON_PYPI: "true"
-  DOCS_JOB_ON: "true"
-  DRAW_DEPENDENCIES: "true"
+  RUN_UNIT_TESTS: "false"
+  RUN_LINT_CHECKS: "false"
+  DOCKER_JOB_ON: "false"
+  PUBLISH_ON_PYPI: "false"
+  DOCS_JOB_ON: "false"
+  DRAW_DEPENDENCIES: "false"
   ##########################
 
   ### DOCKER Job Policy ####

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -314,12 +314,7 @@ jobs:
   ## JOB: Signal for Automated PyPI Upload ##
   check_which_git_branch_we_are_on:
     runs-on: ubuntu-latest
-    needs: set_github_outputs
     if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
-    # Signals only if all below are True:
-    #  - PyPI Job Switch is ON
-    #  - Workflow Event is a 'v*' Tag (e.g. v1.0.0, v-test)
-    #  - Tag is tagging a commit on either the 'master' or 'release' Branch
     env:
       RELEASE_BR: 'release'
       MAIN_BR: 'master'
@@ -363,7 +358,7 @@ jobs:
 
   ## JOB: PYPI UPLOAD ##
   pypi_publish:
-    needs: [test_suite, check_which_git_branch_we_are_on]
+    needs: [set_github_outputs, test_suite, check_which_git_branch_we_are_on]
     uses: boromir674/automated-workflows/.github/workflows/pypi_env.yml@8e97f596067fcbbaa0a6927ec1ee47dce4ab5f1a
     with:
       should_trigger: ${{ needs.set_github_outputs.outputs.PUBLISH_ON_PYPI == 'true' && needs.check_which_git_branch_we_are_on.outputs.AUTOMATED_DEPLOY == 'true' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -424,6 +424,6 @@ jobs:
     with:
       tag: ${{ github.ref_name }}
       draft: ${{ needs.check_which_git_branch_we_are_on.outputs.ENVIRONMENT_NAME == 'TEST_DEPLOYMENT' }}
-      # using the default token provided by GH: ${{ github.token }}, yilds unverified Releases
     secrets:
-      gh_token: ${{ github.token }}
+      # passing the GH_TOKEN, attempting to produce a "verified" Release
+      gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,8 @@ on:
 
 env:
   ### STRESS TEST Job MATRIX ###
-  FULL_MATRIX_STRATEGY: "{\"platform\": [\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"], \"python-version\": [\"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.12\"]}"
+  # FULL_MATRIX_STRATEGY: "{\"platform\": [\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"], \"python-version\": [\"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.12\"]}"
+  FULL_MATRIX_STRATEGY: "{\"platform\": [\"ubuntu-latest\"], \"python-version\": [\"3.10\"]}"
   # Python 3.7 has reached End of Life (EOL) on June 27th, 2023
   # Python 3.12 is in bugfix mode, same as 3.11 -> can start supporting 3.12 it
   UBUNTU_PY310_STRATEGY: "{\"platform\": [\"ubuntu-latest\"], \"python-version\": [\"3.10\"]}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -364,7 +364,6 @@ jobs:
   ## JOB: PYPI UPLOAD ##
   pypi_publish:
     needs: [test_suite, check_which_git_branch_we_are_on]
-    if: always()
     uses: boromir674/automated-workflows/.github/workflows/pypi_env.yml@8e97f596067fcbbaa0a6927ec1ee47dce4ab5f1a
     with:
       should_trigger: ${{ needs.check_which_git_branch_we_are_on.outputs.AUTOMATED_DEPLOY == 'true' }}
@@ -413,3 +412,14 @@ jobs:
       source_code_targets: 'src'
       python_version: '3.10'
       artifacts_dir: 'dependency-graphs'
+
+
+### Make a Github Release ###
+  gh_release:
+    needs: [test_suite, check_which_git_branch_we_are_on]
+    if: ${{ needs.check_which_git_branch_we_are_on.outputs.AUTOMATED_DEPLOY == 'true' }}
+    uses: boromir674/automated-workflows/.github/workflows/gh-release.yml@test
+    name: 'GH Release'
+    with:
+      tag: ${{ github.ref }}
+      draft: ${{ needs.check_which_git_branch_we_are_on.outputs.ENVIRONMENT_NAME == 'TEST_DEPLOYMENT' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -422,5 +422,5 @@ jobs:
     uses: boromir674/automated-workflows/.github/workflows/gh-release.yml@test
     name: 'GH Release'
     with:
-      tag: ${{ github.ref }}
+      tag: ${{ github.ref_name }}
       draft: ${{ needs.check_which_git_branch_we_are_on.outputs.ENVIRONMENT_NAME == 'TEST_DEPLOYMENT' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,20 +26,19 @@ on:
 
 env:
   ### STRESS TEST Job MATRIX ###
-  # FULL_MATRIX_STRATEGY: "{\"platform\": [\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"], \"python-version\": [\"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.12\"]}"
-  FULL_MATRIX_STRATEGY: "{\"platform\": [\"ubuntu-latest\"], \"python-version\": [\"3.10\"]}"
+  FULL_MATRIX_STRATEGY: "{\"platform\": [\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"], \"python-version\": [\"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.12\"]}"
   # Python 3.7 has reached End of Life (EOL) on June 27th, 2023
   # Python 3.12 is in bugfix mode, same as 3.11 -> can start supporting 3.12 it
   UBUNTU_PY310_STRATEGY: "{\"platform\": [\"ubuntu-latest\"], \"python-version\": [\"3.10\"]}"
   TEST_STRATEGY: "{\"platform\": [\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"], \"python-version\":[\"3.10\"]}"
 
   ##### JOB ON/OFF SWITCHES - 1st level overrides #####
-  RUN_UNIT_TESTS: "false"
-  RUN_LINT_CHECKS: "false"
-  DOCKER_JOB_ON: "false"
-  PUBLISH_ON_PYPI: "false"
-  DOCS_JOB_ON: "false"
-  DRAW_DEPENDENCIES: "false"
+  RUN_UNIT_TESTS: "true"
+  RUN_LINT_CHECKS: "true"
+  DOCKER_JOB_ON: "true"
+  PUBLISH_ON_PYPI: "true"
+  DOCS_JOB_ON: "true"
+  DRAW_DEPENDENCIES: "true"
   ##########################
 
   ### DOCKER Job Policy ####
@@ -417,7 +416,7 @@ jobs:
 
 ### Make a Github Release ###
   gh_release:
-    needs: [check_which_git_branch_we_are_on]
+    needs: [test_suite, check_which_git_branch_we_are_on]
     if: ${{ needs.check_which_git_branch_we_are_on.outputs.AUTOMATED_DEPLOY == 'true' }}
     uses: boromir674/automated-workflows/.github/workflows/gh-release.yml@test
     name: 'GH Release'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,30 @@
 Changelog
 =========
 
+2.2.1 (2024-03-11)
+==================
+
+Changes
+^^^^^^^
+
+fix
+"""
+- adjust mkdocs configured template to follow the Gold Standard Snaphost
+
+test
+""""
+- fix building wheel and sdist from gen proj
+
+ci
+""
+- pass PAT 'GH_TOKEN' in GH Release Workflow
+- pass git tag name, ie v2.2.1-rc in GH Release Workflow
+- allow checking for -rc tag regardless of top-level PYPI overide switch
+- add GH Release Job in 'CI/CD Pipeline' Workflow
+- allow a couple of more subprocess low severity cwe reported by bandit
+- generate and push Python Gold Standard to py-gold branch of biskotaki repo
+
+
 2.2.0 (2024-03-10)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -275,9 +275,9 @@ Free/Libre and Open Source Software (FLOSS)
 
 .. Github Releases & Tags
 
-.. |commits_since_specific_tag_on_master| image:: https://img.shields.io/github/commits-since/boromir674/cookiecutter-python-package/v2.2.0/master?color=blue&logo=github
+.. |commits_since_specific_tag_on_master| image:: https://img.shields.io/github/commits-since/boromir674/cookiecutter-python-package/v2.2.1/master?color=blue&logo=github
     :alt: GitHub commits since tagged version (branch)
-    :target: https://github.com/boromir674/cookiecutter-python-package/compare/v2.2.0..master
+    :target: https://github.com/boromir674/cookiecutter-python-package/compare/v2.2.1..master
 
 .. |commits_since_latest_github_release| image:: https://img.shields.io/github/commits-since/boromir674/cookiecutter-python-package/latest?color=blue&logo=semver&sort=semver
     :alt: GitHub commits since latest release (by SemVer)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ copyright = '2022, Konstantinos Lampridis'
 author = 'Konstantinos Lampridis'
 
 # The full version, including alpha/beta/rc tags
-release = '2.2.0'
+release = '2.2.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/contents/35_development/gitops-v2-cheatsheet.md
+++ b/docs/contents/35_development/gitops-v2-cheatsheet.md
@@ -89,12 +89,11 @@ git push origin -d test-distro-docs
 git push origin -d direct-onboarding
 
 git push origin -d release-train
-
+git push origin -d release
 ```
 
 Clean Local with:
 ```shell
 git tag -d board-request
 git tag -d auto-prod
-git checkout release && git rebase master
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "poetry.core.masonry.api"
 ## Also renders on pypi as 'subtitle'
 [tool.poetry]
 name = "cookiecutter_python"
-version = "2.2.0"
+version = "2.2.1"
 description = "1-click Generator of Python Project, from Template with streamlined \"DevOps\" using a powerful CI/CD Pipeline."
 authors = ["Konstantinos Lampridis <k.lampridis@hotmail.com>"]
 maintainers = ["Konstantinos Lampridis <k.lampridis@hotmail.com>"]

--- a/src/cookiecutter_python/__init__.py
+++ b/src/cookiecutter_python/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 
 from . import _logging  # noqa

--- a/src/cookiecutter_python/backend/error_handling/handler_builder.py
+++ b/src/cookiecutter_python/backend/error_handling/handler_builder.py
@@ -1,4 +1,3 @@
-import json
 
 import click
 from software_patterns import SubclassRegistry

--- a/src/cookiecutter_python/backend/error_handling/handler_builder.py
+++ b/src/cookiecutter_python/backend/error_handling/handler_builder.py
@@ -17,8 +17,8 @@ class NonCriticalHandlerBuilder:
 @HandlerBuilder.register_as_subclass('critical')
 class CriticalHandlerBuilder:
     def __call__(self, error):
-        click.echo('{}'.format(error.message))
-        click.echo('Error message: {}'.format(error.error.message))
+        click.echo('{}'.format(str(error)))
+        click.echo('Error message: {}'.format(str(error)))
 
-        context_str = json.dumps(error.context, indent=4, sort_keys=True)
-        click.echo('Context: {}'.format(context_str))
+        # Message that program is exiting due to error
+        click.echo('Exiting due to error')

--- a/src/cookiecutter_python/backend/error_handling/handler_builder.py
+++ b/src/cookiecutter_python/backend/error_handling/handler_builder.py
@@ -1,4 +1,3 @@
-
 import click
 from software_patterns import SubclassRegistry
 

--- a/src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/cicd.md
+++ b/src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/cicd.md
@@ -11,6 +11,4 @@ Flow Chart, of Jobs Dependencies in the Pipeline.
 
 **config: ./.github/workflows/test.yaml**
 
-{# to be evaluated, post generation, during markdown docs build process #}
-{# not during Generation time #}
-{% raw %}{% include 'dockerfile_mermaid.md' %}{% endraw %}
+{% raw %}{% include 'cicd_mermaid.md' %}{% endraw %}

--- a/src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/dockerfile_mermaid.md
+++ b/src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/dockerfile_mermaid.md
@@ -6,5 +6,5 @@
 graph TB;
   python:3.9.16-slim-bullseye --> builder
   python:3.9.16-slim-bullseye --> install
-  builder -. "COPY" .-> install
+  builder -. "requirements.txt" .-> install
 ```

--- a/src/cookiecutter_python/{{ cookiecutter.project_slug }}/scripts/gen_api_refs_pages.py
+++ b/src/cookiecutter_python/{{ cookiecutter.project_slug }}/scripts/gen_api_refs_pages.py
@@ -1,4 +1,5 @@
 """Generate the code reference pages."""
+
 import typing as t
 from pathlib import Path
 
@@ -86,7 +87,6 @@ This page provides documentation for our command line tools.
     # <repo_url>/blob/master/docs/src/artificial_artwork/nst_math.py
 
     # mkdocs_gen_files.set_edit_path(full_doc_path, path)
-
 
 
 # At the end, create a magic, literate navigation file called SUMMARY.md in the

--- a/src/cookiecutter_python/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.pkg_name }}/__main__.py
+++ b/src/cookiecutter_python/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.pkg_name }}/__main__.py
@@ -8,6 +8,7 @@ the python module:
 This is an alternative to directly invoking the cli that uses python as the
 "entrypoint".
 """
+
 from __future__ import absolute_import
 
 from {{ cookiecutter.pkg_name }}.cli import main

--- a/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_build_creates_artifacts.py
+++ b/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_build_creates_artifacts.py
@@ -75,6 +75,13 @@ def test_running_build_creates_source_and_wheel_distros(
         [sys.executable, '-m', 'tox', '-r', '-vv', '-e', 'check'],
         cwd=snapshot_dir,
         check=False,  # prevent raising exception, so we can do clean up
+        # pass the PKG_VERSION env var with value '0.0.1'
+        env={
+            # required by Check environment
+            'PKG_VERSION': '0.0.1',
+            # required due to programmatic execution, in this case
+            'PATH': str(Path(sys.executable).parent),
+        },
     )
 
     # CLEAN UP: Remove .tox/check folder, created by tox

--- a/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py
+++ b/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py
@@ -4,12 +4,15 @@ import pytest
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize('snapshot_name', [
-    # LINT Biskotaki, with sphinx
-    'biskotaki-no-input',
-    # LINT Biskotaki Gold Standard, with mkdocs
-    'biskotaki-gold-standard',
-])
+@pytest.mark.parametrize(
+    'snapshot_name',
+    [
+        # LINT Biskotaki, with sphinx
+        'biskotaki-no-input',
+        # LINT Biskotaki Gold Standard, with mkdocs
+        'biskotaki-gold-standard',
+    ],
+)
 def test_running_lint_passes(snapshot_name, test_root):
     import subprocess
     from pathlib import Path
@@ -18,7 +21,7 @@ def test_running_lint_passes(snapshot_name, test_root):
     # Load Snapshot
     snapshot_dir: Path = test_root / 'data' / 'snapshots' / snapshot_name
     assert snapshot_dir.exists()
-    assert snapshot_dir.is_dir()   
+    assert snapshot_dir.is_dir()
 
     # Programmatically run Lint, with the entrypoint we suggest, for a Dev to run
     res = subprocess.run(  # tox -e lint
@@ -40,12 +43,15 @@ def test_running_lint_passes(snapshot_name, test_root):
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize('snapshot_name', [
-    # Test Case 1: RUFF Biskotaki, with sphinx
-    'biskotaki-no-input',
-    # Test Case 2: RUFF Biskotaki Gold Standard, with mkdocs
-    'biskotaki-gold-standard',
-])
+@pytest.mark.parametrize(
+    'snapshot_name',
+    [
+        # Test Case 1: RUFF Biskotaki, with sphinx
+        'biskotaki-no-input',
+        # Test Case 2: RUFF Biskotaki Gold Standard, with mkdocs
+        'biskotaki-gold-standard',
+    ],
+)
 def test_running_ruff_passes(snapshot_name, test_root):
     import subprocess
     from pathlib import Path
@@ -53,7 +59,7 @@ def test_running_ruff_passes(snapshot_name, test_root):
     # Load Snapshot
     snapshot_dir: Path = test_root / 'data' / 'snapshots' / snapshot_name
     assert snapshot_dir.exists()
-    assert snapshot_dir.is_dir()   
+    assert snapshot_dir.is_dir()
 
     # Programmatically run Lint, with the entrypoint we suggest, for a Dev to run
     res = subprocess.run(  # tox -e ruff

--- a/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py
+++ b/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py
@@ -4,16 +4,21 @@ import pytest
 
 
 @pytest.mark.integration
-def test_running_lint_passes(
-    test_root,
-):
+@pytest.mark.parametrize('snapshot_name', [
+    # LINT Biskotaki, with sphinx
+    'biskotaki-no-input',
+    # LINT Biskotaki Gold Standard, with mkdocs
+    'biskotaki-gold-standard',
+])
+def test_running_lint_passes(snapshot_name, test_root):
     import subprocess
     from pathlib import Path
 
+    # LINT Biskotaki
     # Load Snapshot
-    snapshot_dir: Path = test_root / 'data' / 'snapshots' / 'biskotaki-no-input'
+    snapshot_dir: Path = test_root / 'data' / 'snapshots' / snapshot_name
     assert snapshot_dir.exists()
-    assert snapshot_dir.is_dir()
+    assert snapshot_dir.is_dir()   
 
     # Programmatically run Lint, with the entrypoint we suggest, for a Dev to run
     res = subprocess.run(  # tox -e lint
@@ -22,10 +27,48 @@ def test_running_lint_passes(
         check=False,  # prevent raising exception, so we can do clean up
     )
 
-    # Remove .tox/ folder, created by tox
+    # SANITY verify .tox/lint exists, when using tox 3.x
+    assert (snapshot_dir / '.tox' / 'lint').exists()
+
+    # Remove .tox/lint folder, created by tox 3.x
     import shutil
 
-    shutil.rmtree(snapshot_dir / '.tox')
+    shutil.rmtree(snapshot_dir / '.tox' / 'lint')
+
+    # Check that Code passes Lint out of the box
+    assert res.returncode == 0
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize('snapshot_name', [
+    # Test Case 1: RUFF Biskotaki, with sphinx
+    'biskotaki-no-input',
+    # Test Case 2: RUFF Biskotaki Gold Standard, with mkdocs
+    'biskotaki-gold-standard',
+])
+def test_running_ruff_passes(snapshot_name, test_root):
+    import subprocess
+    from pathlib import Path
+
+    # Load Snapshot
+    snapshot_dir: Path = test_root / 'data' / 'snapshots' / snapshot_name
+    assert snapshot_dir.exists()
+    assert snapshot_dir.is_dir()   
+
+    # Programmatically run Lint, with the entrypoint we suggest, for a Dev to run
+    res = subprocess.run(  # tox -e ruff
+        [sys.executable, '-m', 'tox', '-r', '-vv', '-e', 'ruff'],
+        cwd=snapshot_dir,
+        check=False,  # prevent raising exception, so we can do clean up
+    )
+
+    # SANITY verify .tox/ruff exists, when using tox 3.x
+    assert (snapshot_dir / '.tox' / 'ruff').exists()
+
+    # Remove .tox/ruff folder, created by tox 3.x
+    import shutil
+
+    shutil.rmtree(snapshot_dir / '.tox' / 'ruff')
 
     # Check that Code passes Lint out of the box
     assert res.returncode == 0

--- a/tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py
+++ b/tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py
@@ -45,7 +45,7 @@ def test_snapshot_matches_runtime(snapshot, biskotaki_ci_project, test_root):
 
     # current CI runs tox -e dev, sdist, and wheel meaning it is certain __pycache__ will be created
     # remove all __pycache__ folders and everything nested under them
-    
+
     # for example it is very common for a cpython interpreter to create __pycache__ folders
 
     # for all relative paths, if 'part' __pycache__ is in the path, remove it

--- a/tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py
+++ b/tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py
@@ -45,11 +45,15 @@ def test_snapshot_matches_runtime(snapshot, biskotaki_ci_project, test_root):
 
     # current CI runs tox -e dev, sdist, and wheel meaning it is certain __pycache__ will be created
     # remove all __pycache__ folders and everything nested under them
-    # this is a tiny bit of a hack, but it is the simplest way to fix the problem
+    
+    # for example it is very common for a cpython interpreter to create __pycache__ folders
 
     # for all relative paths, if 'part' __pycache__ is in the path, remove it
     snap_relative_paths_set = set(
         [x for x in snap_relative_paths_set if '__pycache__' not in x.parts]
+    )
+    runtime_relative_paths_set = set(
+        [x for x in runtime_relative_paths_set if '__pycache__' not in x.parts]
     )
 
     # EXCLUDE artifacts, and cache potentially produced if running linters
@@ -61,9 +65,9 @@ def test_snapshot_matches_runtime(snapshot, biskotaki_ci_project, test_root):
     snap_relative_paths_set = set(
         [x for x in snap_relative_paths_set if '.pytest_cache' not in x.parts]
     )
-
-    # EXCLUDE from test dist/ top-level folder
-    snap_relative_paths_set = set([x for x in snap_relative_paths_set if x.parts[0] != 'dist'])
+    runtime_relative_paths_set = set(
+        [x for x in runtime_relative_paths_set if '.pytest_cache' not in x.parts]
+    )
 
     # WHEN we compare the 2 sets of relative Paths
 

--- a/tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py
+++ b/tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py
@@ -51,25 +51,22 @@ def test_snapshot_matches_runtime(snapshot, biskotaki_ci_project, test_root):
     snap_relative_paths_set = set(
         [x for x in snap_relative_paths_set if '__pycache__' not in x.parts]
     )
-    runtime_relative_paths_set = set(
-        [x for x in runtime_relative_paths_set if '__pycache__' not in x.parts]
-    )
 
     # EXCLUDE artifacts, and cache potentially produced if running linters
     snap_relative_paths_set = set(
-        [x for x in snap_relative_paths_set if '.ruff_cached' not in x.parts]
+        [x for x in snap_relative_paths_set if '.ruff_cache' not in x.parts]
     )
-    runtime_relative_paths_set = set(
-        [x for x in runtime_relative_paths_set if '.ruff_cached' not in x.parts]
-    )
-
+    
     # EXCLUDE from test .pytest_cache/ folders too
     snap_relative_paths_set = set(
         [x for x in snap_relative_paths_set if '.pytest_cache' not in x.parts]
     )
-    runtime_relative_paths_set = set(
-        [x for x in runtime_relative_paths_set if '.pytest_cache' not in x.parts]
+
+    # EXCLUDE from test dist/ top-level folder
+    snap_relative_paths_set = set(
+        [x for x in snap_relative_paths_set if x.parts[0] != 'dist']
     )
+
 
     # WHEN we compare the 2 sets of relative Paths
 

--- a/tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py
+++ b/tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py
@@ -56,17 +56,14 @@ def test_snapshot_matches_runtime(snapshot, biskotaki_ci_project, test_root):
     snap_relative_paths_set = set(
         [x for x in snap_relative_paths_set if '.ruff_cache' not in x.parts]
     )
-    
+
     # EXCLUDE from test .pytest_cache/ folders too
     snap_relative_paths_set = set(
         [x for x in snap_relative_paths_set if '.pytest_cache' not in x.parts]
     )
 
     # EXCLUDE from test dist/ top-level folder
-    snap_relative_paths_set = set(
-        [x for x in snap_relative_paths_set if x.parts[0] != 'dist']
-    )
-
+    snap_relative_paths_set = set([x for x in snap_relative_paths_set if x.parts[0] != 'dist'])
 
     # WHEN we compare the 2 sets of relative Paths
 

--- a/tests/test_gold_standard.py
+++ b/tests/test_gold_standard.py
@@ -1,5 +1,6 @@
-from pathlib import Path
 import typing as t
+from pathlib import Path
+
 import pytest
 
 

--- a/tests/test_gold_standard.py
+++ b/tests/test_gold_standard.py
@@ -259,7 +259,9 @@ def test_gs_matches_runtime(gen_gs_project, test_root):
                 assert runtime_file.is_file()
                 assert snap_file.is_file()
                 continue
-
+            # handle cookie.log accident
+            if runtime_file.name == 'cookie.log':
+                continue
             # go line by line and assert each one for easier debugging
             runtime_file_content = runtime_file.read_text().splitlines()
             snap_file_content = snap_file.read_text().splitlines()

--- a/tests/test_gold_standard.py
+++ b/tests/test_gold_standard.py
@@ -259,8 +259,8 @@ def test_gs_matches_runtime(gen_gs_project, test_root):
                 assert runtime_file.is_file()
                 assert snap_file.is_file()
                 continue
-            # handle cookie.log accident
-            if runtime_file.name == 'cookie.log':
+            # handle file with runtime logs
+            if runtime_file.name == 'cookie-py.log':
                 continue
             # go line by line and assert each one for easier debugging
             runtime_file_content = runtime_file.read_text().splitlines()

--- a/tests/test_gold_standard.py
+++ b/tests/test_gold_standard.py
@@ -242,7 +242,14 @@ def test_gs_matches_runtime(gen_gs_project, test_root):
     )
 
     def file_gen() -> t.Iterator[t.Tuple[Path, Path]]:
-        for runtime_file, relative_path in ((rf, rel_path) for rf, rel_path in [(runtime_gs / x, x) for x in sorted(runtime_relative_paths_set - {Path('CHANGELOG.rst')})] if rf.is_file()):
+        for runtime_file, relative_path in (
+            (rf, rel_path)
+            for rf, rel_path in [
+                (runtime_gs / x, x)
+                for x in sorted(runtime_relative_paths_set - {Path('CHANGELOG.rst')})
+            ]
+            if rf.is_file()
+        ):
             yield runtime_file, snapshot_dir / relative_path
 
     debug = True

--- a/tests/test_gold_standard.py
+++ b/tests/test_gold_standard.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-
+import typing as t
 import pytest
 
 
@@ -132,6 +132,14 @@ def test_gs_matches_runtime(gen_gs_project, test_root):
         [x for x in runtime_relative_paths_set if '__pycache__' not in x.parts]
     )
 
+    # for all relative paths, if .ruff_cache/ is in the path, remove it
+    snap_relative_paths_set = set(
+        [x for x in snap_relative_paths_set if '.ruff_cache' not in x.parts]
+    )
+    runtime_relative_paths_set = set(
+        [x for x in runtime_relative_paths_set if '.ruff_cache' not in x.parts]
+    )
+
     # Sanity Check that tests/test_cli.py is part of the comparison below
     assert Path('tests/test_cli.py') in snap_relative_paths_set, (
         f"tests/test_cli.py is missing from Snapshot: {snapshot_dir}\n"
@@ -232,34 +240,37 @@ def test_gs_matches_runtime(gen_gs_project, test_root):
         "-------------------\n"
     )
 
-    automated_files = snap_relative_paths_set - {Path('CHANGELOG.rst')}
+    def file_gen() -> t.Iterator[t.Tuple[Path, Path]]:
+        for runtime_file, relative_path in ((rf, rel_path) for rf, rel_path in [(runtime_gs / x, x) for x in sorted(runtime_relative_paths_set - {Path('CHANGELOG.rst')})] if rf.is_file()):
+            yield runtime_file, snapshot_dir / relative_path
 
     debug = True
     if debug:
-        for relative_path in sorted([x for x in automated_files if x.is_file()]):
-            runtime_file = runtime_gs / relative_path
-            snap_file = snapshot_dir / relative_path
+        for runtime_file, snap_file in ((x, y) for x, y in file_gen()):
+            if runtime_file.suffix == '.png':
+                assert runtime_file.is_file()
+                assert snap_file.is_file()
+                continue
 
             # go line by line and assert each one for easier debugging
-            snap_file_content = snap_file.read_text().splitlines()
             runtime_file_content = runtime_file.read_text().splitlines()
+            snap_file_content = snap_file.read_text().splitlines()
+
             for line_index, line_pair in enumerate(
                 zip(runtime_file_content, snap_file_content)
             ):
                 assert line_pair[0] == line_pair[1], (
-                    f"File: {relative_path} has different content at Runtime than in Snapshot\n"
+                    f"File: {runtime_file.relative_to(runtime_gs)} has different content at Runtime than in Snapshot\n"
                     f"Line Index: {line_index}\n"
-                    "Line Runtime: {line_pair[0]}\n"
-                    "Line Snapshot: {line_pair[1]}\n"
+                    f"Line Runtime: {line_pair[0]}\n"
+                    f"Line Snapshot: {line_pair[1]}\n"
                 )
             assert len(runtime_file_content) == len(snap_file_content)
     else:
-        for relative_path in sorted([x for x in automated_files if x.is_file()]):
-            runtime_file = runtime_gs / relative_path
-            snap_file = snapshot_dir / relative_path
+        for runtime_file, snap_file in ((x, y) for x, y in file_gen()):
 
             assert runtime_file.read_text() == snap_file.read_text(), (
-                f"File: {relative_path} has different content at Runtime than in Snapshot\n"
+                f"File: {runtime_file.relative_to(runtime_gs)} has different content at Runtime than in Snapshot\n"
                 "-------------------\n"
                 f"Runtime: {runtime_file}\n"
                 "-------------------\n"

--- a/tox.ini
+++ b/tox.ini
@@ -145,14 +145,14 @@ usedevelop = true
 [testenv:dev]
 description = Using `python3` in PATH: Install in 'edit' mode & Test
 basepython = {env:TOXPYTHON:python3}
-deps = tox  # required when enabling --run-integration pytest flag
+deps = tox == 3.27.1  # required when enabling --run-integration pytest flag
 usedevelop = true
 commands = pytest -ra {posargs:-n auto} {toxinidir}{/}tests
 
 [testenv:dev-cov]
 description = Using `python3` in PATH: Install in 'edit' mode, Test & measure Coverage
 basepython = {env:TOXPYTHON:python3}
-deps = tox  # required when enabling --run-integration pytest flag
+deps = tox == 3.27.1  # required when enabling --run-integration pytest flag
 usedevelop = true
 commands =
     pytest -ra --cov --cov-report=term-missing \


### PR DESCRIPTION
- ci: generate and push Python Gold Standard to py-gold branch of biskotaki repo
- fix: adjust mkdocs configured template to follow the Gold Standard Snaphost
- refactor(isort): apply isort
- refactor(black): apply black
- refactor(ruff): apply ruff
- refactor(black): apply black
- test: fix building wheel and sdist from gen proj
- fix code
- refactor(black): apply black
- ci: allow a couple of more subprocess low severity cwe reported by bandit
- ci(gh): add GH Release Job in 'CI/CD Pipeline' Workflow
- empemeral: set Full Matrix Strategy to single Job for quick CI
- empemeral: 'Power OFF' all CI Checks
- ci: allow checking for -rc tag regardless of top-level PYPI overide switch
- empemeral: do not 'need' test_suite for running gh_release Job, for quick CI
- ci: pass git tag name, ie v2.2.1-rc in GH Release Workflow
- add comments
- call Workflow with secret passing in
- ci: pass PAT 'GH_TOKEN' in GH Release Workflow
- add comments
- add comments
