### PR TITLE
Identifying and running Required Checks, before being accepted into Release Train

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Link: https://github.com/boromir674/biskotaki/actions/runs/4157571651
    a. **Job Matrix**, spanning different `platform`'s and `python version`'s
 
       1. Platforms: `ubuntu-latest`, `macos-latest`
-      2. Python Interpreters: `3.6`, `3.7`, `3.8`, `3.9`, `3.10`
+      2. Python Interpreters: `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`
    b. **Parallel Job** execution, generated from the `matrix`, that runs the `Test Suite`
    c. **Artifact** store of **Source** and **Wheel** Distributions, factoring Platform and Python Version
 
@@ -88,7 +88,7 @@ Next, **create** a file, let's call it ``gen-config.yml``, with the following co
         email: john.doe@something.org
         github_username: john-doe
         project_short_description: 'Demo Generated Project Description'
-        initialize_git_repo: no
+        initialize_git_repo: 'no'
         interpreters: {"supported-interpreters": ["3.8", "3.9", "3.10", "3.11"]}
 
 


### PR DESCRIPTION
Merging into test-docs-dev, to run Required Checks before being accepted into the Release Train.

  The Required Checks are defined in the Protection Rules of 'test-docs-dev' branch.
  