### PR TITLE
Merge all migration to uv and CI redesign work into 'dev'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,7 @@ jobs:
             echo "[INFO] Activating virtual environment for Linux/MacOS"
             . .venv/bin/activate
           fi
-          pytest -ra -n auto --run-requires_uv --run-network_bound -vvs
+          pytest -ra --run-requires_uv --run-network_bound -vvs -k test_logging
 
 ## PYDEPS
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,406 @@
+# CI Pipeline
+
+name: CI Pipeline
+# primarily serves as quick feedback on every push
+# on feature-branches, should be as quick as possible
+#  runs only tests, type check, docs build dynamically based on changes
+
+# THIS PIPELINE IS UNDER DEVELOPMENT
+# when it is feature-full, we shall add a "changes-dection" job to optimize pipeline by skipping jobs that do need to run
+# and only run the jobs that are needed
+
+on:
+  push:
+    branches:
+      - '*'
+      # except main, dev, release, branches
+      - '!main'
+      - '!dev'
+      - '!release'
+      - '!try-ci'
+
+env:
+  # OVERRIDES
+  # OV_TEST_INTEGRATION: true
+  OV_TEST_UNIT: true
+
+
+jobs:
+  # For Test Suite this pipeline aims for speed
+  # so for feature branches test in edit mode
+  # for 'high' branches (ie dev) run sdist/wheel tests
+
+## Temporary TEST against reproducible build
+  # build:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Set up Python 3.10
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: '3.10'
+
+  #     # Install uv to manage pinned versions
+  #     - name: Install the latest version of uv
+  #       uses: astral-sh/setup-uv@v5
+  #       with:
+  #         version: "latest"
+
+  #     # Build Source Distribution
+  #     # - name: 'Build Source Distribution'
+  #     #   run: uv build --sdist
+
+  #     # Export "pinned" (exact) dependencies' versions in requirements.txt format
+  #     - name: 'Export pinned Prod + Test dependencies'
+  #       run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
+
+  #     # Install dependencies in virtualenv
+  #     - name: 'Install "Prod + Test" dependencies'
+  #       run: |
+  #         uv venv
+  #         uv pip install -r requirements.txt
+
+  #     # here the .venv is built with the exact dependencies
+
+  #     # Install Package (without dependencies)
+  #     - name: 'Install Package without dependencies'
+  #       run: uv pip install --no-deps -e .
+
+  #     # CI Artifact UPLOAD built env
+  #     - name: Upload Built Env in CI Artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:      
+  #         overwrite: false
+  #         # we pass to path value, only the necessary "transferable" packages to be used in other job
+  #         # if this solution persists then todo exclude __pychache__
+  #         path: .venv/lib/python3.10/site-packages
+  #         name: env
+  #         if-no-files-found: error
+
+  # RUN UNIT TESTS
+  test_unit:
+    if: ${{ vars.OV_TEST_UNIT != 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      # - uses: actions/checkout@v4
+      # - name: Set up Python 3.10
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.10'
+
+      # - name: Download site packages Artifacts
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: env
+      #     path: env
+      #     # pattern: env/*
+      #     # merge-multiple: true
+
+      # - run: ls -la env
+      # - run: python -m site
+      # - run: which python
+
+      #   # try to put the site packages in the system's python site packages
+      # - name: Place site packages from CI to system's python site packages
+      #   env:
+      #     SITE_PACKAGES: /opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/
+      #   run: |
+      #     sudo cp -r env/* ${{ env.SITE_PACKAGES }}
+      #     sudo chown -R $USER:$USER ${{ env.SITE_PACKAGES }}
+
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      # Install uv to manage pinned versions
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      # Export "pinned" (exact) dependencies' versions in requirements.txt format
+      - name: 'Export pinned Prod + Test dependencies'
+        run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
+
+      - run: uv venv
+
+      # Install dependencies in virtualenv
+      - name: 'Install "Prod + Test" dependencies'
+        run: uv pip install -r requirements.txt
+
+      # here the .venv is built with the exact dependencies
+
+      # Install Package (without dependencies)
+      - name: 'Install Package without dependencies'
+        run: uv pip install --no-deps -e .
+
+      # Run tests
+      - name: 'Run tests'
+        run: uv run pytest -ra -n auto
+
+
+  # RUN INTEGRATION TESTS
+  test_integration:
+    # needs: build
+    if: vars.OV_TEST_INTEGRATION == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # - uses: actions/checkout@v4
+      # - name: Set up Python 3.10
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.10'
+
+      # - name: Download site packages Artifacts
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: env
+      #     path: env
+
+      # - run: ls -la env
+      # - run: python -m site
+
+      # - name: Place site packages from CI to system's python site packages
+      #   env:
+      #     SITE_PACKAGES: /opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/
+      #   run: |
+      #     sudo cp -r env/* ${{ env.SITE_PACKAGES }}
+      #     sudo chown -R $USER:$USER ${{ env.SITE_PACKAGES }}
+
+      # # Install uv which tests depends on at runtime
+      # - name: Install the latest version of uv
+      #   uses: astral-sh/setup-uv@v5
+      #   with:
+      #     version: "latest"
+
+
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      # Install uv to manage pinned versions
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      # Export "pinned" (exact) dependencies' versions in requirements.txt format
+      - name: 'Export pinned Prod + Test dependencies'
+        run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
+
+      - run: uv venv
+
+      # Install dependencies in virtualenv
+      - name: 'Install "Prod + Test" dependencies'
+        run: uv pip install -r requirements.txt
+
+      # here the .venv is built with the exact dependencies
+
+      # Install Package (without dependencies)
+      - name: 'Install Package without dependencies'
+        run: uv pip install --no-deps -e .
+
+      # Run Integration tests
+      - name: 'Run Integration tests'
+        if: always()
+        run: |
+          # leverage uv to install other runtime test dependencies in the system site-packages!
+
+          uv pip install 'tox<4.0'  # integration tests dependency
+
+          # Isolate flaky tests
+          uv run pytest -ra -vvs --run-slow -k via_build_module
+          uv run pytest -ra -vvs --run-slow -k test_build_creates_artifacts
+
+          # Run eveything once again for sanity
+          uv run pytest -ra -n auto --run-requires_uv --run-slow --run-network_bound -vvs -k 'test_cli or build_backend_sdist or test_build_creates_artifacts or test_lint_passes'
+
+
+  # STATIC CODE ANALYSIS: mypy, ruff, isort, black, bandit, mccabe, prospector, etc
+  sca:
+    if: vars.OV_SCA == 'true'
+    uses: ./.github/workflows/sca-job.yml
+    with:
+      python_version: '3.10'
+      allow_failure: true
+      # force_styles: 'true'
+
+
+  smaple_matrix_test:
+    runs-on: ${{ matrix.platform }}
+    # trigger if event is pr to dev
+    if: github.event_name == 'pull_request' && github.base_ref == 'dev'
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.10]
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - uses: actions/checkout@v4
+
+      - name: 'Export pinned Prod + Test dependencies'
+        run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          uv run pytest -ra -n auto --run-slow --run-network_bound -vvs
+
+## PYDEPS
+
+## TYPE CHECK
+
+## DOCS
+
+## Build an SDist and run against Test Suite
+  sdist:
+    if: vars.OV_SDIST != 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      ## Build Source Distribution ##
+      - name: 'Build Source Distribution'
+        run: uv build --sdist --out-dir dist
+
+      - name: 'Export pinned Prod + Test dependencies'
+        run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
+
+      - run: uv venv
+
+      # Install dependencies in virtualenv
+      - name: 'Install "Prod + Test" dependencies'
+        run: uv pip install -r requirements.txt
+
+      # here the .venv is built with the exact dependencies
+
+      # Install Package from SDist
+      - name: 'Install Package from SDist, without dependencies'
+        run: uv pip install --no-deps dist/*.tar.gz
+
+      # Run tests
+      - name: 'Run tests'
+        run: uv run pytest -ra -n auto
+
+## Build a Wheel and run against Test Suite
+  wheel:
+    if: vars.OV_WHEEL != 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      ## Build Wheel Distribution ##
+      - name: 'Build Wheel Distribution'
+        run: uv build --wheel --out-dir dist
+
+      - name: 'Export pinned Prod + Test dependencies'
+        run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
+
+      - run: uv venv
+
+      # Install dependencies in virtualenv
+      - name: 'Install "Prod + Test" dependencies'
+        run: uv pip install -r requirements.txt
+
+      # here the .venv is built with the exact dependencies
+
+      # Install Package from Wheel
+      - name: 'Install Package from SDist, without dependencies'
+        run: uv pip install --no-deps dist/*.whl
+
+      # Run tests
+      - name: 'Run tests'
+        run: uv run pytest -ra -n auto
+
+## Build all Wheels and run against Test Suite
+  all_wheels:
+    if: vars.OV_ALL_WHEELS != 'false'
+    runs-on: ubuntu-latest
+    env:
+      module_name: cookiecutter_python
+      # assuming project "declares" 1 python module (in the package)
+      # assuming a pure-python package is being built (otherwise needs platform-specific path)!
+      WHEEL_FILE: 'cookiecutter_python-*.whl'
+    steps:
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - uses: actions/checkout@v4
+
+      ## Build Wheel Distribution ##
+      - name: 'Build Wheel Distribution for Package and its Dependencies'
+        run: 'pip wheel --wheel-dir dist .'
+
+        # --find-links dist --use-feature=fast-deps --use-feature=2020-resolver
+
+        # run: uv build --wheel --all-packages --out-dir dist
+
+      - run: mkdir module_wheel/
+      - run: mv dist/${{ env.WHEEL_FILE }} module_wheel/
+
+      - run: uv venv
+
+      - run: uv pip install --no-deps dist/*.whl
+      # - run: uv pip install --no-deps $(ls dist/*.whl)
+      # - run: find dist -name "*.whl" -print0 | xargs -0 uv pip install --no-deps
+
+      # here we need to manually extract the wheel file path, asserting there is only 1
+      - name: Extract Module Wheel file path
+        id: module_wheel_path
+        run: echo "module_wheel_path=$(ls module_wheel/*.whl)" >> $GITHUB_OUTPUT
+
+      - name: Install module wheel and download test extras from pypi
+        run: uv pip install "${{ steps.module_wheel_path.outputs.module_wheel_path }}[test]"
+
+      # TODO: use pinned test deps, instead of "rolling" the test deps as done above
+
+      # Install Prod Wheels
+      # - name: 'Install "Prod Wheels and leverage "extras" to install test deps'
+      #   run: uv pip install --no-deps "dist/*.whl[test]"
+
+      # Run tests
+      - name: 'Run tests'
+        run: uv run pytest -ra -n auto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,11 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv
-          uv pip install -r requirements.txt
+          uv pip install --no-deps -r requirements.txt
+
+      # Install the Package Wheel
+      - name: Install our Package Wheel
+        run: uv pip install --no-deps dist/*.whl
 
       # Run tests
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,9 @@ jobs:
   ### FASTER JOBS ###
 
   # INSTALL PACKAGE in Edit mode and run Test Suite against it
+  ## Unless override, default trigger 'always'
   test_unit:
-    if: ${{ vars.NONE == 'IMPOSSIBLE' && vars.OV_TEST_UNIT != 'false' }}
+    if: ${{ vars.OV_TEST_UNIT != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +72,7 @@ jobs:
   # Build PACKAGE SDist and run Test Suite against it
   ## Unless override, default trigger 'always'
   sdist:
-    if: ${{ vars.NONE == 'IMPOSSIBLE' && vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')}}
+    if: ${{ vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -111,7 +112,7 @@ jobs:
   # BUILD PACKAGE Wheel and run Tests Suite against it
   ## Unless override, default trigger 'always'
   wheel:
-    if: vars.NONE == 'IMPOSSIBLE' && vars.OV_WHEEL != 'false'
+    if: vars.OV_WHEEL != 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -151,7 +152,7 @@ jobs:
   # BUILD ALL WHEELS and run Test Suite against them
   ## Unless override, default trigger 'always'
   all_wheels:
-    if: vars.NONE == 'IMPOSSIBLE' && vars.OV_ALL_WHEELS != 'false'  # Unless override, default trigger 'always'
+    if: vars.OV_ALL_WHEELS != 'false'  # Unless override, default trigger 'always'
     runs-on: ubuntu-latest
     env:
       module_name: cookiecutter_python
@@ -210,7 +211,7 @@ jobs:
   ## Unless override, default trigger is (only) on PR to dev
   sca:
     # Unless override, default trigger is (only) on PR to dev
-    if: always() || vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     uses: ./.github/workflows/sca-job.yml
     with:
       python_version: '3.10'
@@ -266,10 +267,10 @@ jobs:
           # Run eveything once again for sanity
           uv run pytest -ra -n auto --run-requires_uv --run-slow --run-network_bound -vvs -k 'test_cli or build_backend_sdist or test_build_creates_artifacts or test_lint_passes'
 
-  # CROSS PLATFORM TESTING: slower due to Test Matrix containing Windows Job
+  # CROSS PLATFORM TESTING: 15s on Ubuntu, 25 on mac, 35 on windows
   ## Unless override, default trigger is (only) on PR to dev
   sample_matrix_test:
-    if: always() || vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ${{ matrix.platform }}
     # trigger if event is pr to dev
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,84 +30,11 @@ jobs:
   # so for feature branches test in edit mode
   # for 'high' branches (ie dev) run sdist/wheel tests
 
-## Temporary TEST against reproducible build
-  # build:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Set up Python 3.10
-  #       uses: actions/setup-python@v5
-  #       with:
-  #         python-version: '3.10'
-
-  #     # Install uv to manage pinned versions
-  #     - name: Install the latest version of uv
-  #       uses: astral-sh/setup-uv@v5
-  #       with:
-  #         version: "latest"
-
-  #     # Build Source Distribution
-  #     # - name: 'Build Source Distribution'
-  #     #   run: uv build --sdist
-
-  #     # Export "pinned" (exact) dependencies' versions in requirements.txt format
-  #     - name: 'Export pinned Prod + Test dependencies'
-  #       run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
-
-  #     # Install dependencies in virtualenv
-  #     - name: 'Install "Prod + Test" dependencies'
-  #       run: |
-  #         uv venv
-  #         uv pip install -r requirements.txt
-
-  #     # here the .venv is built with the exact dependencies
-
-  #     # Install Package (without dependencies)
-  #     - name: 'Install Package without dependencies'
-  #       run: uv pip install --no-deps -e .
-
-  #     # CI Artifact UPLOAD built env
-  #     - name: Upload Built Env in CI Artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:      
-  #         overwrite: false
-  #         # we pass to path value, only the necessary "transferable" packages to be used in other job
-  #         # if this solution persists then todo exclude __pychache__
-  #         path: .venv/lib/python3.10/site-packages
-  #         name: env
-  #         if-no-files-found: error
-
   # RUN UNIT TESTS
   test_unit:
     if: ${{ vars.OV_TEST_UNIT != 'false' }}
     runs-on: ubuntu-latest
     steps:
-      # - uses: actions/checkout@v4
-      # - name: Set up Python 3.10
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.10'
-
-      # - name: Download site packages Artifacts
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: env
-      #     path: env
-      #     # pattern: env/*
-      #     # merge-multiple: true
-
-      # - run: ls -la env
-      # - run: python -m site
-      # - run: which python
-
-      #   # try to put the site packages in the system's python site packages
-      # - name: Place site packages from CI to system's python site packages
-      #   env:
-      #     SITE_PACKAGES: /opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/
-      #   run: |
-      #     sudo cp -r env/* ${{ env.SITE_PACKAGES }}
-      #     sudo chown -R $USER:$USER ${{ env.SITE_PACKAGES }}
-
       - uses: actions/checkout@v4
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
@@ -147,35 +74,6 @@ jobs:
     if: vars.OV_TEST_INTEGRATION == 'true'
     runs-on: ubuntu-latest
     steps:
-      # - uses: actions/checkout@v4
-      # - name: Set up Python 3.10
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.10'
-
-      # - name: Download site packages Artifacts
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: env
-      #     path: env
-
-      # - run: ls -la env
-      # - run: python -m site
-
-      # - name: Place site packages from CI to system's python site packages
-      #   env:
-      #     SITE_PACKAGES: /opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/
-      #   run: |
-      #     sudo cp -r env/* ${{ env.SITE_PACKAGES }}
-      #     sudo chown -R $USER:$USER ${{ env.SITE_PACKAGES }}
-
-      # # Install uv which tests depends on at runtime
-      # - name: Install the latest version of uv
-      #   uses: astral-sh/setup-uv@v5
-      #   with:
-      #     version: "latest"
-
-
       - uses: actions/checkout@v4
       - name: Set up Python 3.10
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,8 +315,17 @@ jobs:
 
       # Run tests
       - name: Run tests
+        shell: bash
         run: |
-          uv run pytest -ra -n auto --run-requires_uv --run-network_bound -vvs
+          if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
+            echo "[INFO] Activating virtual environment for Windows"
+            . .venv/Scripts/activate
+          else
+            # Linux and MacOS
+            echo "[INFO] Activating virtual environment for Linux/MacOS"
+            . .venv/bin/activate
+          fi
+          pytest -ra -n auto --run-requires_uv --run-network_bound -vvs
 
 ## PYDEPS
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,18 +24,12 @@ on:
     branches:  # ALLOWED Base Branches
       - dev
 
-env:
-  # OVERRIDES
-  # OV_TEST_INTEGRATION: true
-  OV_TEST_UNIT: true
-
-
 jobs:
   # For Test Suite this pipeline aims for speed
   # so for feature branches test in edit mode
   # for 'high' branches (ie dev) run sdist/wheel tests
 
-  # RUN UNIT TESTS
+  # RUN UNIT TESTS in Edit MODE
   test_unit:
     if: ${{ vars.OV_TEST_UNIT != 'false' }}
     runs-on: ubuntu-latest
@@ -64,8 +58,8 @@ jobs:
 
       # here the .venv is built with the exact dependencies
 
-      # Install Package (without dependencies)
-      - name: 'Install Package without dependencies'
+      # Install Package in EDIT mode (without dependencies)
+      - name: 'Install Package in Edit mode, without dependencies'
         run: uv pip install --no-deps -e .
 
       # Run tests
@@ -75,8 +69,7 @@ jobs:
 
   # RUN INTEGRATION TESTS
   test_integration:
-    # needs: build
-    if: vars.OV_TEST_INTEGRATION == 'true'
+    if: vars.OV_TEST_INTEGRATION == 'true' || (github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -125,6 +118,7 @@ jobs:
 
   # STATIC CODE ANALYSIS: mypy, ruff, isort, black, bandit, mccabe, prospector, etc
   sca:
+    # Unless override, default trigger is (only) on PR to dev
     if: vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     uses: ./.github/workflows/sca-job.yml
     with:
@@ -133,9 +127,10 @@ jobs:
       force_styles: ${{ github.event_name == 'pull_request' && github.base_ref == 'dev' && 'true' || 'false' }}
 
   sample_matrix_test:
+    # Unless override, default trigger is (only) on PR to dev
+    if: vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ${{ matrix.platform }}
     # trigger if event is pr to dev
-    if: github.event_name == 'pull_request' && github.base_ref == 'dev'
     strategy:
       fail-fast: false
       matrix:
@@ -147,13 +142,22 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
+      - name: Install uv
+        # if: matrix.platform != 'windows-latest'
+        shell: bash
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      # - name: Install the latest version of uv
+      #   uses: astral-sh/setup-uv@v5
+      #   with:
+      #     version: "latest"
 
       - uses: actions/checkout@v4
 
+      # Build Package Wheel
+      - run: uv build --wheel --out-dir dist
+
+      # Install exact Prod + Test dependencies
       - name: 'Export pinned Prod + Test dependencies'
         run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
 
@@ -162,6 +166,7 @@ jobs:
           uv venv
           uv pip install -r requirements.txt
 
+      # Run tests
       - name: Run tests
         run: |
           uv run pytest -ra -n auto --run-slow --run-network_bound -vvs
@@ -174,7 +179,8 @@ jobs:
 
 ## Build an SDist and run against Test Suite
   sdist:
-    if: vars.OV_SDIST != 'false'
+    # Unless override, default trigger 'always'
+    if: vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -213,7 +219,7 @@ jobs:
 
 ## Build a Wheel and run against Test Suite
   wheel:
-    if: vars.OV_WHEEL != 'false'
+    if: vars.OV_WHEEL != 'false'  # Unless override, default trigger 'always'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -252,7 +258,7 @@ jobs:
 
 ## Build all Wheels and run against Test Suite
   all_wheels:
-    if: vars.OV_ALL_WHEELS != 'false'
+    if: vars.OV_ALL_WHEELS != 'false'  # Unless override, default trigger 'always'
     runs-on: ubuntu-latest
     env:
       module_name: cookiecutter_python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,8 +275,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # platform: [ubuntu-latest, macos-latest, windows-latest]
-        platform: [windows-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        # platform: [windows-latest]
         python-version: ['3.10']
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,15 +222,14 @@ jobs:
 
   # STATIC CODE ANALYSIS: mypy, ruff, isort, black, bandit, mccabe, prospector, etc
   sca:
-    if: vars.OV_SCA == 'true'
+    if: vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     uses: ./.github/workflows/sca-job.yml
     with:
       python_version: '3.10'
-      allow_failure: true
-      # force_styles: 'true'
+      allow_failure: ${{ github.event_name == 'pull_request' && github.base_ref == 'dev' && 'false' || 'true' }}
+      force_styles: ${{ github.event_name == 'pull_request' && github.base_ref == 'dev' && 'true' || 'false' }}
 
-
-  smaple_matrix_test:
+  sample_matrix_test:
     runs-on: ${{ matrix.platform }}
     # trigger if event is pr to dev
     if: github.event_name == 'pull_request' && github.base_ref == 'dev'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
   # INSTALL PACKAGE in Edit mode and run Test Suite against it
   test_unit:
-    if: ${{ vars.NONE == 'IMPOSSIBLE' && vars.OV_TEST_UNIT != 'false' }}
+    if: ${{ vars.OV_TEST_UNIT != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
   # Build PACKAGE SDist and run Test Suite against it
   ## Unless override, default trigger 'always'
   sdist:
-    if: ${{ vars.NONE == 'IMPOSSIBLE' && vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')}}
+    if: ${{ vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -111,7 +111,7 @@ jobs:
   # BUILD PACKAGE Wheel and run Tests Suite against it
   ## Unless override, default trigger 'always'
   wheel:
-    if: vars.NONE == 'IMPOSSIBLE' && vars.OV_WHEEL != 'false'
+    if: vars.OV_WHEEL != 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -151,7 +151,7 @@ jobs:
   # BUILD ALL WHEELS and run Test Suite against them
   ## Unless override, default trigger 'always'
   all_wheels:
-    if: vars.NONE == 'IMPOSSIBLE' && vars.OV_ALL_WHEELS != 'false'  # Unless override, default trigger 'always'
+    if: vars.OV_ALL_WHEELS != 'false'  # Unless override, default trigger 'always'
     runs-on: ubuntu-latest
     env:
       module_name: cookiecutter_python
@@ -210,7 +210,7 @@ jobs:
   ## Unless override, default trigger is (only) on PR to dev
   sca:
     # Unless override, default trigger is (only) on PR to dev
-    if: always() || vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     uses: ./.github/workflows/sca-job.yml
     with:
       python_version: '3.10'
@@ -269,7 +269,7 @@ jobs:
   # CROSS PLATFORM TESTING: slower due to Test Matrix containing Windows Job
   ## Unless override, default trigger is (only) on PR to dev
   sample_matrix_test:
-    if: always() || vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ${{ matrix.platform }}
     # trigger if event is pr to dev
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
       - '!dev'
       - '!release'
       - '!try-ci'
+  # when PR to dev open/push event happens
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:  # ALLOWED Base Branches
+      - dev
 
 env:
   # OVERRIDES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,10 @@ jobs:
       # Run tests
       - name: Run tests
         shell: bash
+        env:
+          # log deletion post hook fails on windows, due to permission error! (other process is using the file, so removing is denied)
+          # windows spawn multiple processes, so log deletion is not possible, even when running 1 Single Unit Test
+          BUG_LOG_DEL_WIN: 'permission_error'
         run: |
           if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
             echo "[INFO] Activating virtual environment for Windows"
@@ -326,7 +330,6 @@ jobs:
             . .venv/bin/activate
           fi
           pytest -ra --run-requires_uv --run-network_bound -vvs -k test_logging
-
 ## PYDEPS
 
 ## TYPE CHECK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
   # so for feature branches test in edit mode
   # for 'high' branches (ie dev) run sdist/wheel tests
 
-  # RUN UNIT TESTS in Edit MODE
+  ### FASTER JOBS ###
+
+  # INSTALL PACKAGE in Edit mode and run Test Suite against it
   test_unit:
     if: ${{ vars.OV_TEST_UNIT != 'false' }}
     runs-on: ubuntu-latest
@@ -66,120 +68,9 @@ jobs:
       - name: 'Run tests'
         run: uv run pytest -ra -n auto
 
-
-  # RUN INTEGRATION TESTS
-  test_integration:
-    if: vars.OV_TEST_INTEGRATION == 'true' || (github.event_name == 'pull_request' && github.base_ref == 'dev')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      # Install uv to manage pinned versions
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
-
-      # Export "pinned" (exact) dependencies' versions in requirements.txt format
-      - name: 'Export pinned Prod + Test dependencies'
-        run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
-
-      - run: uv venv
-
-      # Install dependencies in virtualenv
-      - name: 'Install "Prod + Test" dependencies'
-        run: uv pip install -r requirements.txt
-
-      # here the .venv is built with the exact dependencies
-
-      # Install Package (without dependencies)
-      - name: 'Install Package without dependencies'
-        run: uv pip install --no-deps -e .
-
-      # Run Integration tests
-      - name: 'Run Integration tests'
-        if: always()
-        run: |
-          # leverage uv to install other runtime test dependencies in the system site-packages!
-
-          uv pip install 'tox<4.0'  # integration tests dependency
-
-          # Isolate flaky tests
-          uv run pytest -ra -vvs --run-slow -k via_build_module
-          uv run pytest -ra -vvs --run-slow -k test_build_creates_artifacts
-
-          # Run eveything once again for sanity
-          uv run pytest -ra -n auto --run-requires_uv --run-slow --run-network_bound -vvs -k 'test_cli or build_backend_sdist or test_build_creates_artifacts or test_lint_passes'
-
-
-  # STATIC CODE ANALYSIS: mypy, ruff, isort, black, bandit, mccabe, prospector, etc
-  sca:
-    # Unless override, default trigger is (only) on PR to dev
-    if: vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
-    uses: ./.github/workflows/sca-job.yml
-    with:
-      python_version: '3.10'
-      allow_failure: ${{ github.event_name == 'pull_request' && github.base_ref == 'dev' && 'false' || 'true' }}
-      force_styles: ${{ github.event_name == 'pull_request' && github.base_ref == 'dev' && 'true' || 'false' }}
-
-  sample_matrix_test:
-    # Unless override, default trigger is (only) on PR to dev
-    if: vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
-    runs-on: ${{ matrix.platform }}
-    # trigger if event is pr to dev
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.10]
-    steps:
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install uv
-        # if: matrix.platform != 'windows-latest'
-        shell: bash
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-
-      # - name: Install the latest version of uv
-      #   uses: astral-sh/setup-uv@v5
-      #   with:
-      #     version: "latest"
-
-      - uses: actions/checkout@v4
-
-      # Build Package Wheel
-      - run: uv build --wheel --out-dir dist
-
-      # Install exact Prod + Test dependencies
-      - name: 'Export pinned Prod + Test dependencies'
-        run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
-
-      - name: Install dependencies
-        run: |
-          uv venv
-          uv pip install -r requirements.txt
-
-      # Run tests
-      - name: Run tests
-        run: |
-          uv run pytest -ra -n auto --run-slow --run-network_bound -vvs
-
-## PYDEPS
-
-## TYPE CHECK
-
-## DOCS
-
-## Build an SDist and run against Test Suite
+  # Build PACKAGE SDist and run Test Suite against it
+  ## Unless override, default trigger 'always'
   sdist:
-    # Unless override, default trigger 'always'
     if: vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ubuntu-latest
     steps:
@@ -217,7 +108,8 @@ jobs:
       - name: 'Run tests'
         run: uv run pytest -ra -n auto
 
-## Build a Wheel and run against Test Suite
+  # BUILD PACKAGE Wheel and run Tests Suite against it
+  ## Unless override, default trigger 'always'
   wheel:
     if: vars.OV_WHEEL != 'false'  # Unless override, default trigger 'always'
     runs-on: ubuntu-latest
@@ -256,7 +148,8 @@ jobs:
       - name: 'Run tests'
         run: uv run pytest -ra -n auto
 
-## Build all Wheels and run against Test Suite
+  # BUILD ALL WHEELS and run Test Suite against them
+  ## Unless override, default trigger 'always'
   all_wheels:
     if: vars.OV_ALL_WHEELS != 'false'  # Unless override, default trigger 'always'
     runs-on: ubuntu-latest
@@ -312,3 +205,116 @@ jobs:
       # Run tests
       - name: 'Run tests'
         run: uv run pytest -ra -n auto
+
+  # STATIC CODE ANALYSIS: mypy, ruff, isort, black, bandit, mccabe, prospector, etc
+  ## Unless override, default trigger is (only) on PR to dev
+  sca:
+    # Unless override, default trigger is (only) on PR to dev
+    if: vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    uses: ./.github/workflows/sca-job.yml
+    with:
+      python_version: '3.10'
+      allow_failure: ${{ github.event_name == 'pull_request' && github.base_ref == 'dev' && 'false' || 'true' }}
+      force_styles: ${{ github.event_name == 'pull_request' && github.base_ref == 'dev' && 'true' || 'false' }}
+
+
+  # RUN INTEGRATION TESTS: slower due to automated installations involved via pip
+  ## Unless override, default trigger is (only) on PR to dev
+  test_integration:
+    if: vars.OV_TEST_INTEGRATION == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      # Install uv to manage pinned versions
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      # Export "pinned" (exact) dependencies' versions in requirements.txt format
+      - name: 'Export pinned Prod + Test dependencies'
+        run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
+
+      - run: uv venv
+
+      # Install dependencies in virtualenv
+      - name: 'Install "Prod + Test" dependencies'
+        run: uv pip install -r requirements.txt
+
+      # here the .venv is built with the exact dependencies
+
+      # Install Package (without dependencies)
+      - name: 'Install Package without dependencies'
+        run: uv pip install --no-deps -e .
+
+      # Run Integration tests
+      - name: 'Run Integration tests'
+        if: always()
+        run: |
+          # leverage uv to install other runtime test dependencies in the system site-packages!
+
+          uv pip install 'tox<4.0'  # integration tests dependency
+
+          # Isolate flaky tests
+          uv run pytest -ra -vvs --run-slow -k via_build_module
+          uv run pytest -ra -vvs --run-slow -k test_build_creates_artifacts
+
+          # Run eveything once again for sanity
+          uv run pytest -ra -n auto --run-requires_uv --run-slow --run-network_bound -vvs -k 'test_cli or build_backend_sdist or test_build_creates_artifacts or test_lint_passes'
+
+  # CROSS PLATFORM TESTING: slower due to Test Matrix containing Windows Job
+  ## Unless override, default trigger is (only) on PR to dev
+  sample_matrix_test:
+    if: vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    runs-on: ${{ matrix.platform }}
+    # trigger if event is pr to dev
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.10]
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        # if: matrix.platform != 'windows-latest'
+        shell: bash
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      # - name: Install the latest version of uv
+      #   uses: astral-sh/setup-uv@v5
+      #   with:
+      #     version: "latest"
+
+      - uses: actions/checkout@v4
+
+      # Build Package Wheel
+      - run: uv build --wheel --out-dir dist
+
+      # Install exact Prod + Test dependencies
+      - name: 'Export pinned Prod + Test dependencies'
+        run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv pip install -r requirements.txt
+
+      # Run tests
+      - name: Run tests
+        run: |
+          uv run pytest -ra -n auto --run-slow --run-network_bound -vvs
+
+## PYDEPS
+
+## TYPE CHECK
+
+## DOCS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,8 @@ jobs:
         env:
           # log deletion post hook fails on windows, due to permission error! (other process is using the file, so removing is denied)
           # windows spawn multiple processes, so log deletion is not possible, even when running 1 Single Unit Test
-          BUG_LOG_DEL_WIN: 'permission_error'
+          BUG_LOG_DEL_WIN: 'permission_error'  # required on Windows Job
+          PY_WHEEL: 1 # required on Windows Job
         run: |
           if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
             echo "[INFO] Activating virtual environment for Windows"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
   # INSTALL PACKAGE in Edit mode and run Test Suite against it
   test_unit:
-    if: ${{ vars.OV_TEST_UNIT != 'false' }}
+    if: ${{ 'false' && vars.OV_TEST_UNIT != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
   # Build PACKAGE SDist and run Test Suite against it
   ## Unless override, default trigger 'always'
   sdist:
-    if: vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: ${{'false' && vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -111,7 +111,7 @@ jobs:
   # BUILD PACKAGE Wheel and run Tests Suite against it
   ## Unless override, default trigger 'always'
   wheel:
-    if: vars.OV_WHEEL != 'false'  # Unless override, default trigger 'always'
+    if: vars.OV_WHEEL != 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -210,7 +210,7 @@ jobs:
   ## Unless override, default trigger is (only) on PR to dev
   sca:
     # Unless override, default trigger is (only) on PR to dev
-    if: vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: always() || vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     uses: ./.github/workflows/sca-job.yml
     with:
       python_version: '3.10'
@@ -221,7 +221,7 @@ jobs:
   # RUN INTEGRATION TESTS: slower due to automated installations involved via pip
   ## Unless override, default trigger is (only) on PR to dev
   test_integration:
-    if: vars.OV_TEST_INTEGRATION == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: always() || vars.OV_TEST_INTEGRATION == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -270,7 +270,7 @@ jobs:
   # CROSS PLATFORM TESTING: slower due to Test Matrix containing Windows Job
   ## Unless override, default trigger is (only) on PR to dev
   sample_matrix_test:
-    if: vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: always() || vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ${{ matrix.platform }}
     # trigger if event is pr to dev
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
   # INSTALL PACKAGE in Edit mode and run Test Suite against it
   test_unit:
-    if: ${{ vars.OV_TEST_UNIT != 'false' }}
+    if: ${{ vars.NONE == 'IMPOSSIBLE' && vars.OV_TEST_UNIT != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
   # Build PACKAGE SDist and run Test Suite against it
   ## Unless override, default trigger 'always'
   sdist:
-    if: ${{ vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')}}
+    if: ${{ vars.NONE == 'IMPOSSIBLE' && vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -111,7 +111,7 @@ jobs:
   # BUILD PACKAGE Wheel and run Tests Suite against it
   ## Unless override, default trigger 'always'
   wheel:
-    if: vars.OV_WHEEL != 'false'
+    if: vars.NONE == 'IMPOSSIBLE' && vars.OV_WHEEL != 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -151,7 +151,7 @@ jobs:
   # BUILD ALL WHEELS and run Test Suite against them
   ## Unless override, default trigger 'always'
   all_wheels:
-    if: vars.OV_ALL_WHEELS != 'false'  # Unless override, default trigger 'always'
+    if: vars.NONE == 'IMPOSSIBLE' && vars.OV_ALL_WHEELS != 'false'  # Unless override, default trigger 'always'
     runs-on: ubuntu-latest
     env:
       module_name: cookiecutter_python
@@ -210,7 +210,7 @@ jobs:
   ## Unless override, default trigger is (only) on PR to dev
   sca:
     # Unless override, default trigger is (only) on PR to dev
-    if: vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: always() || vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     uses: ./.github/workflows/sca-job.yml
     with:
       python_version: '3.10'
@@ -269,7 +269,7 @@ jobs:
   # CROSS PLATFORM TESTING: slower due to Test Matrix containing Windows Job
   ## Unless override, default trigger is (only) on PR to dev
   sample_matrix_test:
-    if: vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: always() || vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ${{ matrix.platform }}
     # trigger if event is pr to dev
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,7 @@ jobs:
             echo "[INFO] Activating virtual environment for Linux/MacOS"
             . .venv/bin/activate
           fi
-          pytest -ra -n auto --run-requires_uv --run-network_bound -vvs
+          pytest -ra --run-requires_uv --run-network_bound -vvs -k 'test_cookiecutter_context[gold_standard]'
 
 ## PYDEPS
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,14 +285,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        # if: matrix.platform != 'windows-latest'
-        shell: bash
+        if: matrix.platform != 'windows-latest'
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
-      # - name: Install the latest version of uv
-      #   uses: astral-sh/setup-uv@v5
-      #   with:
-      #     version: "latest"
+      - name: Install the latest version of uv
+        if: matrix.platform == 'windows-latest'
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
   # INSTALL PACKAGE in Edit mode and run Test Suite against it
   test_unit:
-    if: ${{ 'false' && vars.OV_TEST_UNIT != 'false' }}
+    if: ${{ vars.OV_SDIST == 'IMPOSSIBLE' && vars.OV_TEST_UNIT != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
   # Build PACKAGE SDist and run Test Suite against it
   ## Unless override, default trigger 'always'
   sdist:
-    if: ${{'false' && vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')}}
+    if: ${{vars.OV_SDIST == 'IMPOSSIBLE' && vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -311,7 +311,7 @@ jobs:
       # Run tests
       - name: Run tests
         run: |
-          uv run pytest -ra -n auto --run-slow --run-network_bound -vvs
+          uv run pytest -ra -n auto --run-requires_uv --run-network_bound -vvs
 
 ## PYDEPS
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
   # INSTALL PACKAGE in Edit mode and run Test Suite against it
   test_unit:
-    if: ${{ vars.OV_SDIST == 'IMPOSSIBLE' && vars.OV_TEST_UNIT != 'false' }}
+    if: ${{ vars.NONE == 'IMPOSSIBLE' && vars.OV_TEST_UNIT != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
   # Build PACKAGE SDist and run Test Suite against it
   ## Unless override, default trigger 'always'
   sdist:
-    if: ${{vars.OV_SDIST == 'IMPOSSIBLE' && vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')}}
+    if: ${{ vars.NONE == 'IMPOSSIBLE' && vars.OV_SDIST != 'false' || (vars.OV_SDIST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -111,7 +111,7 @@ jobs:
   # BUILD PACKAGE Wheel and run Tests Suite against it
   ## Unless override, default trigger 'always'
   wheel:
-    if: vars.OV_WHEEL != 'false'
+    if: vars.NONE == 'IMPOSSIBLE' && vars.OV_WHEEL != 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -151,7 +151,7 @@ jobs:
   # BUILD ALL WHEELS and run Test Suite against them
   ## Unless override, default trigger 'always'
   all_wheels:
-    if: vars.OV_ALL_WHEELS != 'false'  # Unless override, default trigger 'always'
+    if: vars.NONE == 'IMPOSSIBLE' && vars.OV_ALL_WHEELS != 'false'  # Unless override, default trigger 'always'
     runs-on: ubuntu-latest
     env:
       module_name: cookiecutter_python
@@ -221,7 +221,7 @@ jobs:
   # RUN INTEGRATION TESTS: slower due to automated installations involved via pip
   ## Unless override, default trigger is (only) on PR to dev
   test_integration:
-    if: always() || vars.OV_TEST_INTEGRATION == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: vars.OV_TEST_INTEGRATION == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -254,7 +254,6 @@ jobs:
 
       # Run Integration tests
       - name: 'Run Integration tests'
-        if: always()
         run: |
           # leverage uv to install other runtime test dependencies in the system site-packages!
 
@@ -276,7 +275,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        # platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [windows-latest]
         python-version: ['3.10']
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.10]
+        python-version: ['3.10']
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,7 @@ jobs:
             echo "[INFO] Activating virtual environment for Linux/MacOS"
             . .venv/bin/activate
           fi
-          pytest -ra --run-requires_uv --run-network_bound -vvs -k 'test_cookiecutter_context[gold_standard]'
+          pytest -ra --run-requires_uv --run-network_bound -vvs -k 'context_with_expected_values[gold_standard]'
 
 ## PYDEPS
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,8 @@ jobs:
             echo "[INFO] Activating virtual environment for Linux/MacOS"
             . .venv/bin/activate
           fi
-          pytest -ra --run-requires_uv --run-network_bound -vvs -k test_logging
+          pytest -ra -n auto --run-requires_uv --run-network_bound -vvs
+
 ## PYDEPS
 
 ## TYPE CHECK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,7 @@ jobs:
 
       # Install the Package Wheel
       - name: Install our Package Wheel
+        shell: bash
         run: uv pip install --no-deps dist/*.whl
 
       # Run tests

--- a/.github/workflows/policy_lint.yml
+++ b/.github/workflows/policy_lint.yml
@@ -153,6 +153,8 @@ jobs:
         if: ${{ matrix.platform != 'windows-latest' }}
         run: tox -e prospector -vv -s false
 
+
+  # TODO: extract a reusable workflow that uses bandit to host security analysis on github!
   bandit:
     name: "Bandit: Security Analysis"
     runs-on: ubuntu-latest

--- a/.github/workflows/sca-job.yml
+++ b/.github/workflows/sca-job.yml
@@ -1,0 +1,90 @@
+#################################
+## PYTHON STATIC CODE ANALYSIS ##
+##      Reusable Workflow      ##
+#################################
+
+# Static Code Analysis (SCA) is a set of techniques for examining source code
+# without executing it.
+
+on:
+  workflow_call:
+    inputs:
+      # Allow top-level workflow to decide if this job should run
+      enable_job:
+        required: false
+        type: boolean
+        default: true
+      allow_failure:
+        required: false
+        description: 'Allow this job to fail'
+        type: boolean
+        default: false
+      force_styles:
+        required: false
+        description: 'Force styles to be applied'
+        type: boolean
+        default: true
+      ## Parametrizing Runtime Environment (ie py version)
+      python_version:
+        required: false
+        description: 'Python runtime version to use'
+        type: string
+        default: '3.10'
+      ## Parametrizing Code Analysis Acceptance Criteria
+      pylint_threshold:
+        required: false
+        type: string
+        default: '8.0'  # out of 10
+    # secrets
+    # outputs
+
+
+jobs:
+  lint:
+    name: "Static Code Analysis"
+    runs-on: ubuntu-latest
+    if: inputs.enable_job == true
+    env:
+      LINT_ARGS: "tests src/cookiecutter_python/backend src/cookiecutter_python/handle scripts"
+      LINT_EXCLUDES: 'tests/data/snapshots'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ inputs.python_version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      ## Ruff ##
+      - name: 'Ruff: Require Project to pass Ruff Checks'
+        run: uvx ruff check ${{ env.LINT_ARGS }}
+
+      ## Isort ##
+      - name: 'Isort: Require Semantic and Alphabetic order of the Python Imports'
+        if: always()
+        run: uvx isort --skip ${{ env.LINT_EXCLUDES }} --check ${{ env.LINT_ARGS }}
+
+      ## Black ##
+      - name: 'Black: Require Project Style to be followed by the Python Code'
+        if: always()
+        run: uvx black --check --skip-string-normalization --exclude ${{ env.LINT_EXCLUDES }} --config pyproject.toml ${{ env.LINT_ARGS }}
+
+      ## Pyflakes, Pyroma, McCabe, DodgyRun, Profile Validator ##
+      - name: Run prospector on application source code 
+        if: always()
+        run: uvx prospector[with_pyroma] src
+
+      - name: Run prospector on test source code 
+        if: always()
+        run: uvx prospector[with_pyroma] tests
+
+      ## Bandit ##
+      - name: Run Bandit for Security Analysis
+        if: always()
+        run: |
+          uv venv
+          uv pip install 'bandit[toml]' 'bandit-sarif-formatter==1.1.1'
+          uv run bandit -r -c pyproject.toml -x 'src/cookiecutter_python/{{ cookiecutter.project_slug }}/' src
+    continue-on-error: ${{ inputs.allow_failure }}

--- a/.github/workflows/test-job.yml
+++ b/.github/workflows/test-job.yml
@@ -1,0 +1,344 @@
+name: "Test Job"
+
+on:
+  workflow_call:
+    inputs:
+      typecheck_policy:
+        required: false
+        type: string
+        default: "1"
+        description: "0 = Off, 1 = On, 2 = Allow Fail"
+
+      # JOB_MATRIX
+      job_matrix:
+        required: false
+        type: string
+        default: "{\"platform\": [\"ubuntu-latest\"], \"python-version\": [\"3.10\"]}"
+
+      # POLICY
+      run_policy:
+        required: false
+        type: string
+        default: '1'
+        description: "0 = Off, 1 = On"
+
+      # TODO support this feature
+      # # BUILD_INSTALLATION
+      # build_installation:
+      #   required: false
+      #   type: string
+      #   default: 'edit sdist wheel'
+      #   description: "Code Installation Modes, for running Tests"
+
+      # ARTIFACT NAME
+      artifact_name:
+        required: false
+        type: string
+        default: 'dist'
+        description: "CI Artifact Name (id / alias) for uploading Distros, such as files .tar.gz, .whl(s)"
+
+    ### OUTPUTS ###
+    # Map the workflow outputs to job outputs
+    outputs:
+      PEP_VERSION:
+        description: "PEP version of the wheel file"
+        value: ${{ jobs.test_suite.outputs.PEP_VERSION }}
+      # COVERAGE_ARTIFACT:
+      #   description: "CI Artifact Name (id / alias) of uploaded Coverage XML"
+      #   value: ${{ jobs.test_build.outputs.COVERAGE_ARTIFACT }}
+
+jobs:
+  # RUN TEST SUITE ON ALL PLATFORMS
+  test_suite:
+    runs-on: ${{ matrix.platform }}
+    if: always() && inputs.run_policy != 0
+    strategy:
+      matrix: ${{fromJSON(inputs.job_matrix)}}
+      fail-fast: false
+    outputs:
+      PEP_VERSION: ${{ steps.extract_wheel_info.outputs.PEP_VERSION }}
+      # COVERAGE_ARTIFACT: ${{ steps.set_coverage_artifact.outputs.COVERAGE_ARTIFACT }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      WHEELS_PIP_DIR: "wheels-pip"
+        # --cov-report=html:{envdir}/htmlcov \
+      PYTEST_ARGS: >
+        -ra --cov --cov-report=term-missing \
+        --cov-context=test \
+        --cov-report=xml:coverage.{envname}.xml \
+        -n auto tests
+      # log deletion post hook fails on windows, due to permission error! (other process is using the file, so removing is denied)
+      # windows spawn multiple processes, so log deletion is not possible, even when running 1 Single Unit Test
+      BUG_LOG_DEL_WIN: 'permission_error'
+
+    steps:
+      - run: 'echo "OS: ${{ matrix.platform }}, Python: ${{ matrix.python-version }}"'
+
+      # Setup Python
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        if: matrix.platform != 'windows-latest'
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Install uv
+        if: matrix.platform == 'windows-latest'
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - uses: actions/checkout@v4
+
+      # ### Sanity Check that folder is Compatible for Python Distro / Build ###
+      # - run: uvx pyroma --directory .
+
+      # # TYPE CHECKING with MYPY
+      # - name: Do Type Checking
+      #   if: matrix.platform != 'windows-latest'
+      #   env:
+      #     PKG: src/cookiecutter_python  # for DRYness
+      #     MYPYPATH: src/stubs/  # REQUIRED for mypy to find our custom stubs
+      #   shell: bash
+      #   run: |
+      #     uv export --no-emit-project --no-dev --extra typing --frozen --format requirements-txt -o requirements.txt
+      #     uv venv
+      #     uv pip install -r requirements.txt
+
+      #     # mypy does not like, by default, multiple conftest.py (ses pytest) files
+      #     # so we trick mypy into believing that tests is a package, because this way
+      #     # pytest can distinguish between our 2 conftest.py files
+
+      #     # create empty __init__.py in tests, temporarily
+      #     touch tests/__init__.py
+
+      #     echo "[INFO] Running mypy for type checking"
+
+      #     uv run mypy --show-error-codes \
+      #     --exclude tests/data \
+      #     "${PKG}/hooks" \
+      #     "${PKG}/backend" "${PKG}/handle" \
+      #     "${PKG}/utils.py" "${PKG}/exceptions.py" \
+      #     "${PKG}/cli.py" "${PKG}/cli_handlers.py" \
+      #     "${PKG}/__main__.py" "${PKG}/__init__.py"
+
+      #   # TODO start typechecking tests
+      #   # TODO add the --check-untyped-defs flag
+
+      # # delete temporarily created empty __init__.py in tests
+      # - if: matrix.platform != 'windows-latest' && always()
+      #   run: rm tests/__init__.py
+
+      ### Check if Requested RC Pipeline ###
+      - name: "Update Source Sem Ver with Release Candidate *-rc' suffix"
+        if: ${{ startsWith(github.event.ref, 'refs/tags/v') && contains(github.event.ref, '-rc') }}
+        shell: bash
+        run: |
+          # Extract PROD Sem Ver
+          SEMVER="$(grep -E -o '^version\s*=\s*\".*\"' pyproject.toml | cut -d'"' -f2)"
+
+          # Derive RC Sem Ver
+          RC_SEMVER="${SEMVER}-rc"
+
+          ## Set Source Sem Ver to Release Candidate Sem Ver ##
+          # if needed: chmod +x ./scripts/distro-sem-ver-bump.sh
+          sh ./scripts/distro-sem-ver-bump.sh "${RC_SEMVER}"
+
+      # UV Export Prod + Test Dependencies (without package)
+      - name: "Export exact 'Prod + Test' Dependencies in requirements.txt format"
+        run: uv export --no-emit-project --no-dev --extra test --frozen --format requirements-txt -o requirements.txt
+
+      - name: Install exact 'Prod + Test' Dependencies
+        # activate explicitly for windows %#$ bug, to maybe offer a workaround for windows unable for uv pip to find test-env automatically
+        shell: bash
+        run: |
+          uv venv
+          if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
+            echo "[INFO] Activating virtual environment for Windows"
+            . .venv/Scripts/activate
+          fi
+          echo "[INFO] Installing exact 'Prod + Test' Dependencies"
+          uv pip install --no-deps -r requirements.txt
+
+      #### Install in EDIT mode and Run TESTS ####
+      - name: 'Run tests'
+        shell: bash  # to solve issue on windows ci
+        run: |
+          if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
+            echo "[INFO] Activating virtual environment for Windows"
+            . .venv/Scripts/activate
+          fi
+          uv pip install --no-deps -e .
+
+          # DEBUG
+          uv run --active pytest -ra -vvs -k test_gs_matches_runtime
+
+          # uv run pytest ${{ env.PYTEST_ARGS }}
+          # uv run pytest -ra --cov --cov-report=term-missing \
+          #   --cov-context=test \
+          #   --cov-report=xml:coverage.test-edit.xml \
+          #   -n auto tests
+
+      #### Build WHEEL/SDIST Distros, Install Wheel and Run TESTS
+      - name: 'Build Wheel/Sdist distros, using uv and poetry.core.masonry.api'
+        shell: bash
+        run: |
+          set -o pipefail
+          uv build --out-dir dist . 2>&1 | tee test_output.log
+
+      - run: mkdir verification
+      - name: Verify packaged Wheel/Sdist Distros are valid according to python standards
+        shell: bash
+        working-directory: verification
+        run: |
+          uv venv check-env
+          if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
+            echo "[INFO] Activating virtual environment for Windows"
+            . check-env/Scripts/activate
+          fi
+          uv pip install poetry-core pyroma 'twine >=5.0.0, <6.0.0'
+          # --active
+
+          # Check .tar.gz file using 'pyroma' command
+          echo "[INFO] Running pyroma on the sdist"
+          uv run --active pyroma --file "$(ls ../dist/*.tar.gz)"
+
+          # Check both .whl and .tar.gz files using 'twine check' command
+          echo "[INFO] Running twine check on the sdist and wheel"
+          uv run --active python -m twine check ../dist/*
+
+      ## UV Build WHEEL - TESTS ##
+      - name: Install Wheel and Run Test Suite
+        shell: bash  # to solve issue on windows ci
+        run: |
+          if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
+            echo "[INFO] Activating virtual environment for Windows"
+            . .venv/Scripts/activate
+          fi
+
+          uv pip uninstall cookiecutter_python
+          uv pip install --no-deps dist/cookiecutter_python-*.whl
+
+          # uv run pytest ${{ env.PYTEST_ARGS }}
+
+          uv run --active pytest -ra --cov --cov-report=term-missing \
+            --cov-context=test \
+            --cov-report=xml:coverage.test-wheel.xml \
+            -n auto tests
+
+      - name: Extract PEP Version
+        id: extract_wheel_info
+        shell: bash
+        run: |
+          # Extract PEP version from wheel file name
+          WHEEL_FILE=$(ls dist/cookiecutter_python-*.whl)
+
+          # extract file name from wheel file
+          WHEEL_NAME="$(basename $WHEEL_FILE)"
+
+          echo "WHEEL_NAME=$WHEEL_NAME" >> $GITHUB_ENV
+
+          # extract pep version from wheel file name, supporting patterns such as below:
+          # - '1.15.0rc0' from 'cookiecutter_python-1.15.0rc0-py3-none-any.whl'
+          # - '1.2.12' from 'cookiecutter_python-1.2.12-py3-none-any.whl'
+          # - '1.2.12' from 'cookiecutter_python-1.2.12-cp3-abi3-any.whl'
+          # - '3.0.7' from 'cookiecutter_python-3.0.7-jy3-none-any.whl'
+          # - '8.9.37dev0' from 'cookiecutter_python-8-9-37dev0-jy3-none-win32.whl'
+          # - '8.9.37dev0' from 'cookiecutter_python-8-9-37dev0-jy3-none-linux_i386.whl'
+
+          PEP_VERSION=$(echo $WHEEL_NAME | cut -d'-' -f2 | sed 's/-/./g')
+          echo "PEP_VERSION=$PEP_VERSION" >> $GITHUB_OUTPUT
+
+          echo "[INFO] Extracted PEP version: $PEP_VERSION"
+          ls -l "${WHEEL_FILE}"
+
+      #### Build All Wheels, install and Test
+      - name: Build All Wheels
+        run: pip wheel --wheel-dir dist-wheels .
+
+      - name: Show Wheels, produced using 'pip', for Distro and its Requirements
+        run: ls -l dist-wheels/
+
+      - name: Derive Module Wheel distro file path
+        id: module_wheel_path
+        shell: bash
+        run: |
+          mkdir module_wheel/
+          mv dist-wheels/cookiecutter_python*.whl module_wheel/
+          echo "MODULE_WHEEL_PATH=$(ls module_wheel/*.whl)" >> $GITHUB_OUTPUT
+
+      - name: Install Wheels of Dependencies
+        shell: bash
+        run: |
+          rm -rf .venv
+          uv venv
+          if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
+            echo "[INFO] Activating virtual environment for Windows"
+            . .venv/Scripts/activate
+          fi
+          uv pip install --no-deps dist-wheels/*.whl
+
+      - name: Install module wheel with test extras downloaded at runtime from pypi
+        if: matrix.platform != 'windows-latest'
+        run: uv pip install "${{ steps.module_wheel_path.outputs.MODULE_WHEEL_PATH }}[test]"
+      
+      - if: matrix.platform == 'windows-latest'
+        name: Install module wheel with test extras downloaded at runtime from pypi
+        shell: bash
+        run: |
+          if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
+            echo "[INFO] Activating virtual environment for Windows"
+            . .venv/Scripts/activate
+          fi
+          uv pip install "${{ steps.module_wheel_path.outputs.MODULE_WHEEL_PATH }}[test]"
+
+      # Run tests
+      - name: 'Run tests'
+        # run: uv run pytest ${{ env.PYTEST_ARGS }}
+        shell: bash  # to solve issue on windows ci
+        run: |
+          if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
+            echo "[INFO] Activating virtual environment for Windows"
+            . .venv/Scripts/activate
+          fi
+          uv run --active pytest -ra --cov --cov-report=term-missing \
+            --cov-report=html:test-wheels/htmlcov --cov-context=test \
+            --cov-report=xml:coverage.test-wheels.xml \
+            -n auto tests
+
+      ## Code Coverage ## TODO; enable combine by moving each .coverage file to other dir to avoid override of subsequent coverage invocations with pytest
+      - name: "Combine Coverage (dev, sdist, wheel) & make Reports"
+        env:
+          COVERAGE_FILE: ${{ github.workspace }}/.coverage
+          OUTPUT_XML: coverage-${{ matrix.platform }}-${{ matrix.python-version }}.xml
+        shell: bash
+        run: |
+          rm -rf .venv
+          uv venv
+          uv pip install 'coverage[toml] >= 5.1' 'diff_cover >=6'
+
+          echo '[INFO] Running coverage'
+          # uv run coverage combine --keep
+          uv run coverage report --skip-covered --show-missing -i
+          uv run coverage xml -o ./${{ env.OUTPUT_XML }} -i
+          # uv run coverage html -d ./htmlcov -i
+
+      - name: "Upload Test Coverage as Artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+        # TODO: implement mechanism for uploading test reports on separate artifact names. then codecov host upload job should be able somehow to get all of them. then change below from true to false
+          overwrite: false
+          name: coverage-${{ matrix.platform }}-${{ matrix.python-version }}.xml
+          path: coverage-${{ matrix.platform }}-${{ matrix.python-version }}.xml
+          if-no-files-found: error
+
+      - name: Upload Source & Wheel distributions as Artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.platform }}-${{ matrix.python-version }}
+          path: dist
+          if-no-files-found: error

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,7 @@ on:
     branches:
       - "*"
       - '!migrate-to-uv'
+      - '!ci-redesign'
     tags:
       - v*
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,11 +22,14 @@ on:
   push:
     branches:
       - "*"
+      - '!migrate-to-uv'
     tags:
       - v*
 
 env:
   ### STRESS TEST Job MATRIX ###
+  # slowest: windows 3.12 (8 mins), slowest python: 3.12 !
+  # TODO: add python 3.11 !!!
   FULL_MATRIX_STRATEGY: "{\"platform\": [\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"], \"python-version\": [\"3.8\", \"3.9\", \"3.10\", \"3.12\"]}"
   # Python 3.7 has reached End of Life (EOL) on June 27th, 2023
   # Python 3.12 is in bugfix mode, same as 3.11 -> can start supporting 3.12 it
@@ -156,176 +159,19 @@ jobs:
       PIPE_CODE_VIZ_POLICY: ${{ steps.derive_code_viz_policy.outputs.POL }}
 
 # RUN TEST SUITE ON ALL PLATFORMS
-  test_suite:
-    runs-on: ${{ matrix.platform }}
+  test:
     needs: set_github_outputs
     if: ${{ needs.set_github_outputs.outputs.TESTS_ENABLED == 'true' }}
-    strategy:
-      matrix: ${{fromJSON(needs.set_github_outputs.outputs.matrix)}}
-    env:
-      WHEELS_PIP_DIR: "wheels-pip"
-    outputs:
-      PEP_VERSION: ${{ steps.extract_wheel_info.outputs.PEP_VERSION }}
-    steps:
-    - run: echo "Platform -> ${{ matrix.platform }} , Python -> ${{ matrix.python-version }}"
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - run: python -m pip install --upgrade pip && python -m pip install tox==3.28 tox-gh-actions
-
-    # TODO: use determinisitc build for type checking
-    # - name: Pin 'Static Type Checking' Dependencies
-    #   run: tox -vv -s false -e pin-deps -- -E typing
-
-    # - name: Do Type Checking
-    #   run: tox -e type -vv -s false
-
-    # we use quick pip solution to deploy
-    - name: Do Type Checking
-      if: matrix.platform != 'windows-latest'
-      env:
-        PKG: src/cookiecutter_python  # for DRYness
-        MYPYPATH: src/stubs/  # REQUIRED for mypy to find our custom stubs
-      shell: bash
-      run: |
-        virtualenv venv
-        # source venv/bin/activate
-
-        # MYPY only Dependencies
-        venv/bin/pip install mypy types-requests==2.27.31 pytest pytest-click types-pyyaml==6.0.12.12
-
-        # Package in Edit mode
-        venv/bin/pip install markupsafe==2.0.1
-        venv/bin/pip install -e '.[typing]'
-
-        # mypy does not like, by default, multiple conftest.py (ses pytest) files
-        # so we trick mypy into believing that tests is a package, because this way
-        # pytest can distinguish between our 2 conftest.py files
-
-        # create empty __init__.py in tests, temporarily
-        touch tests/__init__.py
-
-        echo "[INFO] Running mypy for type checking"
-
-        venv/bin/mypy --show-error-codes \
-        --exclude tests/data \
-        "${PKG}/hooks" \
-        "${PKG}/backend" "${PKG}/handle" \
-        "${PKG}/utils.py" "${PKG}/exceptions.py" \
-        "${PKG}/cli.py" "${PKG}/cli_handlers.py" \
-        "${PKG}/__main__.py" "${PKG}/__init__.py"
-      # NOTE: we excluded the test code from type checking since we do not have reproducible builds
-      # for locally iterating till we solve type check issues on CI
-
-    # delete temporarily created empty __init__.py in tests
-    - if: matrix.platform != 'windows-latest' && always()
-      run: rm tests/__init__.py
-
-    ### Check if Requested RC Pipeline ###
-    - name: "Update Source Sem Ver with Release Candidate *-rc' suffix"
-      if: ${{ startsWith(github.event.ref, 'refs/tags/v') && contains(github.event.ref, '-rc') }}
-      shell: bash
-      run: |
-        # Extract PROD Sem Ver
-        SEMVER="$(grep -E -o '^version\s*=\s*\".*\"' pyproject.toml | cut -d'"' -f2)"
-
-        # Derive RC Sem Ver
-        RC_SEMVER="${SEMVER}-rc"
-
-        ## Set Source Sem Ver to Release Candidate Sem Ver ##
-        # if needed: chmod +x ./scripts/distro-sem-ver-bump.sh
-        sh ./scripts/distro-sem-ver-bump.sh "${RC_SEMVER}"
-
-    ###### TEST SUITE RUN ######
-    - name: Run Unit Tests on Edit, and Sdist; and build Wheels
-      shell: bash
-      run: |
-        set -o pipefail
-        tox -vv -s false | tee test_output.log
-      env:
-        PLATFORM: ${{ matrix.platform }}
-        BUILD_DEST: ${{ env.WHEELS_PIP_DIR }}
-
-    - name: Show produced Wheel(s) for Distro and its Requirements
-      run: ls -l ${{ env.WHEELS_PIP_DIR }}
-
-    # parse test_output.log and match string, like:
-    # Created wheel for cookiecutter_python: filename=cookiecutter_python-1.12.5.dev0-py3-none-any.whl size=199750 sha256=446c75803a6eea1d7ac6af60e0fbb0000483f97ef44eb39469ab3bd997b2a7d8
-
-    # starting line with 'Created wheel for' and extracting filename value and size value
-    - name: Extract Wheel Name and Size
-      id: extract_wheel_info
-      shell: bash
-      run: |
-        WHEEL_INFO=$(grep -E "Created wheel for" test_output.log | sed -E "s/.*filename=([^ ]+) size=([^ ]+) .*/\1 \2/")
-
-        # extract file name
-        WHEEL_NAME=$(echo $WHEEL_INFO | cut -d ' ' -f 1)
-        echo "WHEEL_NAME=$WHEEL_NAME" >> $GITHUB_ENV
-
-        # extract file size
-        WHEEL_SIZE=$(echo $WHEEL_INFO | cut -d ' ' -f 2)
-        echo "WHEEL_SIZE=$WHEEL_SIZE" >> $GITHUB_ENV
-
-        # extract, ie '1.12.5dev0' from 'cookiecutter_python-1.15.0rc0-py3-none-any.whl'
-        PEP_VERSION=$(echo $WHEEL_NAME | sed -E "s/cookiecutter_python-([^ ]+)-py3-none-any.whl/\1/")
-
-        echo "PEP_VERSION=${PEP_VERSION}" >> $GITHUB_OUTPUT
-
-    - run: 'echo "WHEEL_NAME: $WHEEL_NAME SIZE: $WHEEL_SIZE"'
-    - run: 'echo "PEP_VERSION: $PEP_VERSION"'
-
-    - name: Run Test Suite Against Wheel
-      run: tox -e ${{ env.TOX_ENV_WHEEL_TEST }} -s false
-      env:
-        PLATFORM: ${{ matrix.platform }}
-        TOX_ENV_WHEEL_TEST: ${{ (matrix.platform == 'windows-latest' && matrix.python-version != '3.7') && 'wheel-test-windows' || 'wheel-test'}}
-        BUILD_DEST: ${{ env.WHEELS_PIP_DIR }}
-        WHEEL: ${{ env.WHEEL_NAME }}
-
-    ## Code Coverage ##
-    - name: "Combine Coverage (dev, sdist, wheel) & make Reports"
-      run: tox -e coverage --sitepackages -vv -s false
-
-    - name: Rename Coverage Files
-      shell: bash
-      run: |
-        mv ./.tox/coverage.xml ./coverage-${{ matrix.platform }}-${{ matrix.python-version }}.xml
-
-    - name: "Upload Test Coverage as Artifacts"
-      uses: actions/upload-artifact@v4
-      with:
-      # TODO: implement mechanism for uploading test reports on separate artifact names. then codecov host upload job should be able somehow to get all of them. then change below from true to false
-        overwrite: false
-        name: coverage-${{ matrix.platform }}-${{ matrix.python-version }}.xml
-        path: coverage-${{ matrix.platform }}-${{ matrix.python-version }}.xml
-        if-no-files-found: error
-
-    - name: Check for compliance with Python Best Practices
-      shell: bash
-      env:
-        PKG_VERSION: ${{ steps.extract_wheel_info.outputs.PEP_VERSION }}
-        WHEEL_PATH: ${{ env.WHEELS_PIP_DIR }}/${{ env.WHEEL_NAME }}
-      run: |
-        DIST_DIR=dist
-        echo "DIST_DIR=${DIST_DIR}" >> $GITHUB_ENV
-        mkdir ${DIST_DIR}
-        mv ".tox/${DIST_DIR}/cookiecutter_python-${PKG_VERSION}.tar.gz" "${DIST_DIR}"
-        mv "${{ env.WHEEL_PATH }}" "${DIST_DIR}"
-        tox -e check -vv -s false
-
-    - name: Upload Source & Wheel distributions as Artefacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: dist-${{ matrix.platform }}-${{ matrix.python-version }}
-        path: ${{ env.DIST_DIR }}
-        if-no-files-found: error
+    uses: ./.github/workflows/test-job.yml
+    with:
+      # job_matrix: ${{ needs.set_github_outputs.outputs.matrix }}
+      job_matrix: "{\"platform\": [\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"], \"python-version\": [\"3.11\"]}"
+      # job_matrix: "{\"platform\": [\"windows-latest\"], \"python-version\": [\"3.11\"]}"
+      # artifact_name: 'dist'
 
   codecov_coverage_host:
     runs-on: ubuntu-latest
-    needs: test_suite
+    needs: test
     steps:
     - uses: actions/checkout@v4
     - name: Get Codecov binary
@@ -354,15 +200,15 @@ jobs:
 ## DOCKER BUILD and PUBLISH ON DOCKERHUB ##
 # Ref Page: https://automated-workflows.readthedocs.io/en/main/ref_docker/
   docker_build:
-    needs: [set_github_outputs, test_suite]
+    needs: [set_github_outputs, test]
     uses: boromir674/automated-workflows/.github/workflows/docker.yml@v1.14.0
     if: always()
     with:
       acceptance_policy: ${{ needs.set_github_outputs.outputs.PIPE_DOCKER_POLICY }}
       image_slug: "generate-python"
       # target_stage: "some_stage_alias"  # no stage, means no `--target` flag, on build
-      tests_pass: ${{ needs.test_suite.result == 'success' }}
-      tests_run: ${{ !contains(fromJSON('["skipped", "cancelled"]'), needs.test_suite.result) }}
+      tests_pass: ${{ needs.test.result == 'success' }}
+      tests_run: ${{ !contains(fromJSON('["skipped", "cancelled"]'), needs.test.result) }}
       DOCKER_USER: ${{ vars.DOCKER_USER }}
     secrets:
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -413,12 +259,12 @@ jobs:
 
   ## JOB: PYPI UPLOAD ##
   pypi_publish:
-    needs: [set_github_outputs, test_suite, check_which_git_branch_we_are_on]
+    needs: [set_github_outputs, test, check_which_git_branch_we_are_on]
     uses: boromir674/automated-workflows/.github/workflows/pypi_env.yml@test
     with:
       should_trigger: ${{ needs.set_github_outputs.outputs.PUBLISH_ON_PYPI == 'true' && needs.check_which_git_branch_we_are_on.outputs.AUTOMATED_DEPLOY == 'true' }}
       distro_name: cookiecutter_python
-      distro_version: ${{ needs.test_suite.outputs.PEP_VERSION }}
+      distro_version: ${{ needs.test.outputs.PEP_VERSION }}
       pypi_env: '${{ needs.check_which_git_branch_we_are_on.outputs.ENVIRONMENT_NAME }}'
       artifacts_path: downloaded-artifacts
 
@@ -430,6 +276,7 @@ jobs:
 ### STATIC CODE ANALYSIS & LINTING ###
   lint:
     name: Static Code Analysis
+    if: false
     needs: set_github_outputs
     uses: ./.github/workflows/policy_lint.yml
     with:
@@ -441,6 +288,7 @@ jobs:
 
 ### DOCS BUILD/TEST - DOCUMENTATION SITE ###
   docs:
+    if: false
     name: Build Documentation
     needs: set_github_outputs
     # bafaa2c2a014758a4421fe9b5c02ba66dbfdbef6
@@ -453,6 +301,7 @@ jobs:
 
 ### DRAW PYTHON DEPENDENCY GRAPHS ###
   code_visualization:
+    if: false
     needs: set_github_outputs
     name: Code Visualization of Python Imports as Graphs, in .svg
     uses: boromir674/automated-workflows/.github/workflows/python_imports.yml@v1.14.0
@@ -465,7 +314,7 @@ jobs:
 
 ### Make a Github Release ###
   gh_release:
-    needs: [test_suite, check_which_git_branch_we_are_on]
+    needs: [test, check_which_git_branch_we_are_on]
     if: ${{ needs.check_which_git_branch_we_are_on.outputs.AUTOMATED_DEPLOY == 'true' }}
     uses: boromir674/automated-workflows/.github/workflows/gh-release.yml@v1.14.0
     name: 'GH Release'

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,12 @@ notes\.md
 
 cookie-py.log
 dev-notes/
+*\.txt
+temp
+*\.tar\.gz
+docs-dist/
+docs-build/
+WIP.sh
+\.mutmut-cache
+html/
+dist_docs/

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ WIP.sh
 \.mutmut-cache
 html/
 dist_docs/
+coverage\.xml
+coverage\.*
+check-yaml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ extensions = [
     'sphinx_inline_tabs',  # pip install sphinx-inline-tabs ^2023.4.21
 
     ## MERMAID directive ##
-    'sphinxcontrib.mermaid',  # pip install sphinxcontrib-mermaid
+    'sphinxcontrib.mermaid',  # pip install sphinxcontrib-mermaid==1.0.0
 
     ## Render MARKDOWN Files ##
     'myst_parser',  # pip install myst-parser

--- a/docs/contents/20_why_this_package.rst
+++ b/docs/contents/20_why_this_package.rst
@@ -38,12 +38,14 @@ Template Variant
 
 You want `poetry`, but what if you want to develop a `pytest plugin`?
 
-- Generate `module`: a Python Distribution, with python API/sdk
+- Generate **Library**: a Python Distribution, offering modules: python API/sdk
+
+  - configured with **poetry** as built backend, and Package Manager
+
+- Generate **CLI**: a Python Distribution, offering modules and a CLI as entrypoint
+
+  - configured with **poetry** as built backend, and Package Manager
+
+- Generate **Pytest Plugin**: a Python Distribution, designed for a *pytest plugin*
   
-  - configured with `poetry` backend
-- Generate `module+cli`: a Python Distribution, with a CLI and a python API/sdk
-  
-  - configured with `poetry` backend
-- Generate `pytest-plugin`: a Python Distribution, designed for a *pytest plugin*
-  
-  - configured with `setuptools` backend, as Required by `pytest`!
+  - configured with **setuptools** backend, as Required by `pytest`!

--- a/docs/contents/35_development/arch/deps_all.svg
+++ b/docs/contents/35_development/arch/deps_all.svg
@@ -1032,116 +1032,116 @@
 <title>jinja2&#45;&gt;cookiecutter_python_backend_helpers</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M3055.06,-958.42C3062.07,-928.53 3071.39,-866.66 3040.39,-830.29 2948.63,-722.67 2800.95,-881.08 2730.39,-758.52"/>
 </g>
-<!-- poyo -->
-<g id="node60" class="node">
-<title>poyo</title><style>.edge>path:hover{stroke-width:8}</style>
-<polygon fill="#47a1c2" stroke="black" points="2760.39,-1833.51 2757.39,-1837.51 2736.39,-1837.51 2733.39,-1833.51 2706.39,-1833.51 2706.39,-1797.51 2760.39,-1797.51 2760.39,-1833.51"/>
-<text text-anchor="middle" x="2733.39" y="-1813.01" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#000000">poyo</text>
-</g>
-<!-- poyo&#45;&gt;cookiecutter_python_backend_load_config -->
-<g id="edge91" class="edge">
-<title>poyo&#45;&gt;cookiecutter_python_backend_load_config</title><style>.edge>path:hover{stroke-width:8}</style>
-<path fill="none" stroke="black" d="M2760.44,-1810.22C2846.04,-1795.89 3105.39,-1746.39 3105.39,-1672.51 3105.39,-1672.51 3105.39,-1672.51 3105.39,-866.06 3105.39,-779.79 3015.39,-717.09 2952.67,-683.86"/>
-<polygon fill="#47a1c2" stroke="black" points="2954.12,-680.67 2943.63,-679.18 2950.9,-686.88 2954.12,-680.67"/>
-</g>
-<!-- poyo&#45;&gt;cookiecutter -->
-<g id="edge90" class="edge">
-<title>poyo&#45;&gt;cookiecutter</title><style>.edge>path:hover{stroke-width:8}</style>
-<path fill="none" stroke="black" d="M2706.28,-1813.45C2631.83,-1810.11 2426.03,-1797.73 2370.39,-1761.51 2347.9,-1746.87 2332.78,-1719.71 2323.98,-1699.23"/>
-<polygon fill="#47a1c2" stroke="black" points="2327.15,-1697.75 2320.16,-1689.79 2320.66,-1700.38 2327.15,-1697.75"/>
-</g>
 <!-- questionary -->
-<g id="node61" class="node">
+<g id="node60" class="node">
 <title>questionary</title><style>.edge>path:hover{stroke-width:8}</style>
-<polygon fill="#314bc4" stroke="black" points="2220.39,-1617.51 2217.39,-1621.51 2196.39,-1621.51 2193.39,-1617.51 2146.39,-1617.51 2146.39,-1581.51 2220.39,-1581.51 2220.39,-1617.51"/>
-<text text-anchor="middle" x="2183.39" y="-1597.01" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">questionary</text>
+<polygon fill="#319cc4" stroke="black" points="2220.39,-1617.51 2217.39,-1621.51 2196.39,-1621.51 2193.39,-1617.51 2146.39,-1617.51 2146.39,-1581.51 2220.39,-1581.51 2220.39,-1617.51"/>
+<text text-anchor="middle" x="2183.39" y="-1597.01" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#000000">questionary</text>
 </g>
 <!-- questionary&#45;&gt;cookiecutter_python_handle_dialogs_lib_project_name -->
-<g id="edge92" class="edge">
+<g id="edge90" class="edge">
 <title>questionary&#45;&gt;cookiecutter_python_handle_dialogs_lib_project_name</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M2185.04,-1581.32C2190.42,-1525.62 2207.5,-1348.48 2216.19,-1258.3"/>
-<polygon fill="#314bc4" stroke="black" points="2219.69,-1258.57 2217.16,-1248.28 2212.72,-1257.89 2219.69,-1258.57"/>
+<polygon fill="#319cc4" stroke="black" points="2219.69,-1258.57 2217.16,-1248.28 2212.72,-1257.89 2219.69,-1258.57"/>
 </g>
 <!-- requests -->
-<g id="node62" class="node">
+<g id="node61" class="node">
 <title>requests</title><style>.edge>path:hover{stroke-width:8}</style>
-<polygon fill="#6324d0" stroke="black" points="106.89,-1761.51 103.89,-1765.51 82.89,-1765.51 79.89,-1761.51 47.89,-1761.51 47.89,-1725.51 106.89,-1725.51 106.89,-1761.51"/>
+<polygon fill="#2444d0" stroke="black" points="106.89,-1761.51 103.89,-1765.51 82.89,-1765.51 79.89,-1761.51 47.89,-1761.51 47.89,-1725.51 106.89,-1725.51 106.89,-1761.51"/>
 <text text-anchor="middle" x="77.39" y="-1741.01" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">requests</text>
 </g>
 <!-- requests&#45;&gt;cookiecutter_python_backend_hosting_services_handle_hosting_service_check -->
-<g id="edge93" class="edge">
+<g id="edge91" class="edge">
 <title>requests&#45;&gt;cookiecutter_python_backend_hosting_services_handle_hosting_service_check</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M77.39,-1670.51C77.39,-1636.56 114.65,-1646.45 132.39,-1617.51 181.42,-1537.48 205.46,-1428.78 215.77,-1367.93"/>
-<polygon fill="#6324d0" stroke="black" points="219.26,-1368.3 217.43,-1357.86 212.35,-1367.16 219.26,-1368.3"/>
+<polygon fill="#2444d0" stroke="black" points="219.26,-1368.3 217.43,-1357.86 212.35,-1367.16 219.26,-1368.3"/>
 </g>
 <!-- requests&#45;&gt;cookiecutter_python_backend_post_main -->
-<g id="edge94" class="edge">
+<g id="edge92" class="edge">
 <title>requests&#45;&gt;cookiecutter_python_backend_post_main</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M77.63,-1725.24C77.77,-1711.07 77.85,-1690.49 77.39,-1672.51"/>
 <path fill="none" stroke="black" d="M77.39,-1670.51C76.52,-1636.25 34.94,-1648.98 21.39,-1617.51 15.06,-1602.81 20.95,-1597.5 21.39,-1581.51 27.86,-1343.38 -61.35,-1237.01 85.39,-1049.37 155.79,-959.34 219.56,-987.52 297.39,-903.83 323.17,-876.1 310.53,-853.57 340.39,-830.29 385.65,-795.01 415.37,-824.13 464.39,-794.29 521.73,-759.37 525.2,-736.15 568.39,-684.75 589.03,-660.19 584.06,-643.58 611.39,-626.77 657.23,-598.56 797.4,-580.21 891.98,-570.67"/>
-<polygon fill="#6324d0" stroke="black" points="892.52,-574.14 902.13,-569.67 891.83,-567.17 892.52,-574.14"/>
+<polygon fill="#2444d0" stroke="black" points="892.52,-574.14 902.13,-569.67 891.83,-567.17 892.52,-574.14"/>
 </g>
 <!-- requestsfutures -->
-<g id="node63" class="node">
+<g id="node62" class="node">
 <title>requestsfutures</title><style>.edge>path:hover{stroke-width:8}</style>
-<polygon fill="#ad53b6" stroke="black" points="123.89,-1617.51 120.89,-1621.51 99.89,-1621.51 96.89,-1617.51 30.89,-1617.51 30.89,-1581.51 123.89,-1581.51 123.89,-1617.51"/>
+<polygon fill="#7753b6" stroke="black" points="123.89,-1617.51 120.89,-1621.51 99.89,-1621.51 96.89,-1617.51 30.89,-1617.51 30.89,-1581.51 123.89,-1581.51 123.89,-1617.51"/>
 <text text-anchor="middle" x="77.39" y="-1597.01" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">requestsfutures</text>
 </g>
 <!-- requests&#45;&gt;requestsfutures -->
-<g id="edge95" class="edge">
+<g id="edge93" class="edge">
 <title>requests&#45;&gt;requestsfutures</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M77.39,-1670.51C77.39,-1656.45 77.39,-1640.82 77.39,-1627.89"/>
-<polygon fill="#6324d0" stroke="black" points="80.89,-1627.77 77.39,-1617.77 73.89,-1627.77 80.89,-1627.77"/>
+<polygon fill="#2444d0" stroke="black" points="80.89,-1627.77 77.39,-1617.77 73.89,-1627.77 80.89,-1627.77"/>
 </g>
 <!-- requestsfutures&#45;&gt;cookiecutter_python_backend_hosting_services_check_web_hosting_service -->
-<g id="edge96" class="edge">
+<g id="edge94" class="edge">
 <title>requestsfutures&#45;&gt;cookiecutter_python_backend_hosting_services_check_web_hosting_service</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M72.18,-1581.35C57.62,-1529.53 22.19,-1372.77 96.39,-1284 139.8,-1232.06 178.92,-1265.21 244.39,-1248 265.03,-1242.57 287.16,-1236.48 308.01,-1230.61"/>
-<polygon fill="#ad53b6" stroke="black" points="309.14,-1233.93 317.82,-1227.84 307.24,-1227.19 309.14,-1233.93"/>
+<polygon fill="#7753b6" stroke="black" points="309.14,-1233.93 317.82,-1227.84 307.24,-1227.19 309.14,-1233.93"/>
 </g>
 <!-- softwarepatterns -->
-<g id="node64" class="node">
+<g id="node63" class="node">
 <title>softwarepatterns</title><style>.edge>path:hover{stroke-width:8}</style>
-<polygon fill="#f3168f" stroke="black" points="2477.89,-1761.51 2474.89,-1765.51 2453.89,-1765.51 2450.89,-1761.51 2378.89,-1761.51 2378.89,-1725.51 2477.89,-1725.51 2477.89,-1761.51"/>
+<polygon fill="#df16f3" stroke="black" points="2477.89,-1761.51 2474.89,-1765.51 2453.89,-1765.51 2450.89,-1761.51 2378.89,-1761.51 2378.89,-1725.51 2477.89,-1725.51 2477.89,-1761.51"/>
 <text text-anchor="middle" x="2428.39" y="-1741.01" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">softwarepatterns</text>
 </g>
 <!-- softwarepatterns&#45;&gt;cookiecutter_python_backend_error_handling_handler_builder -->
-<g id="edge97" class="edge">
+<g id="edge95" class="edge">
 <title>softwarepatterns&#45;&gt;cookiecutter_python_backend_error_handling_handler_builder</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M2378.62,-1730.17C2315.76,-1714.93 2204.1,-1689 2107.39,-1672.51"/>
 <path fill="none" stroke="black" d="M2107.39,-1670.51C1978.23,-1648.47 1030.43,-1700.92 929.39,-1617.51 894.14,-1588.41 905.39,-1563.22 905.39,-1517.51 905.39,-1517.51 905.39,-1517.51 905.39,-1421.53 905.39,-1359.48 901.99,-1339.67 929.39,-1284 938.97,-1264.53 954.52,-1268.23 962.39,-1248 976.74,-1211.1 968.32,-1198.06 962.39,-1158.91 925.3,-914.08 952.72,-819.6 797.39,-626.77 761.18,-581.82 666.83,-617.76 684.39,-562.78"/>
 </g>
 <!-- softwarepatterns&#45;&gt;cookiecutter_python_backend_generator_generator -->
-<g id="edge98" class="edge">
+<g id="edge96" class="edge">
 <title>softwarepatterns&#45;&gt;cookiecutter_python_backend_generator_generator</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M2464.39,-1598.51C2468.79,-1551.14 2523.29,-1578.68 2557.39,-1545.51 2602.83,-1501.29 2638.06,-1486.59 2631.39,-1423.53"/>
 <path fill="none" stroke="black" d="M2631.39,-1421.53C2629.37,-1407.88 2565.27,-1375.73 2512.88,-1351.59"/>
-<polygon fill="#f3168f" stroke="black" points="2514.14,-1348.31 2503.59,-1347.33 2511.22,-1354.68 2514.14,-1348.31"/>
+<polygon fill="#df16f3" stroke="black" points="2514.14,-1348.31 2503.59,-1347.33 2511.22,-1354.68 2514.14,-1348.31"/>
 </g>
 <!-- softwarepatterns&#45;&gt;cookiecutter_python_backend_hosting_services_web_hosting_service -->
-<g id="edge99" class="edge">
+<g id="edge97" class="edge">
 <title>softwarepatterns&#45;&gt;cookiecutter_python_backend_hosting_services_web_hosting_service</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M2107.39,-1670.51C2040.37,-1659.01 2107.39,-1585.51 2107.39,-1517.51 2107.39,-1517.51 2107.39,-1517.51 2107.39,-1421.53 2107.39,-1363.05 2128.7,-1203.09 2090.39,-1158.91 1919.66,-961.99 1081.15,-891.75 797.99,-873.43"/>
-<polygon fill="#f3168f" stroke="black" points="797.96,-869.92 787.75,-872.77 797.51,-876.9 797.96,-869.92"/>
+<polygon fill="#df16f3" stroke="black" points="797.96,-869.92 787.75,-872.77 797.51,-876.9 797.96,-869.92"/>
 </g>
 <!-- softwarepatterns&#45;&gt;cookiecutter_python_backend_proxy -->
-<g id="edge100" class="edge">
+<g id="edge98" class="edge">
 <title>softwarepatterns&#45;&gt;cookiecutter_python_backend_proxy</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M2464.39,-1598.51C2464.39,-1584.64 2464.39,-1569.43 2464.39,-1555.98"/>
-<polygon fill="#f3168f" stroke="black" points="2467.89,-1555.63 2464.39,-1545.63 2460.89,-1555.63 2467.89,-1555.63"/>
+<polygon fill="#df16f3" stroke="black" points="2467.89,-1555.63 2464.39,-1545.63 2460.89,-1555.63 2467.89,-1555.63"/>
 </g>
 <!-- softwarepatterns&#45;&gt;cookiecutter_python_backend_user_config_proxy -->
-<g id="edge101" class="edge">
+<g id="edge99" class="edge">
 <title>softwarepatterns&#45;&gt;cookiecutter_python_backend_user_config_proxy</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M2435.67,-1725.37C2446.19,-1699.04 2464.39,-1646.79 2464.39,-1600.51"/>
 <path fill="none" stroke="black" d="M2464.39,-1598.51C2468.31,-1551.09 2401.21,-1582.58 2371.39,-1545.51 2352.06,-1521.48 2342.52,-1487.57 2337.83,-1461.6"/>
-<polygon fill="#f3168f" stroke="black" points="2341.28,-1461.02 2336.21,-1451.72 2334.38,-1462.15 2341.28,-1461.02"/>
+<polygon fill="#df16f3" stroke="black" points="2341.28,-1461.02 2336.21,-1451.72 2334.38,-1462.15 2341.28,-1461.02"/>
 </g>
 <!-- softwarepatterns&#45;&gt;cookiecutter_python_handle_dialogs_dialog -->
-<g id="edge102" class="edge">
+<g id="edge100" class="edge">
 <title>softwarepatterns&#45;&gt;cookiecutter_python_handle_dialogs_dialog</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M2631.39,-1421.53C2628.83,-1404.22 2628.29,-1385.04 2628.57,-1368.15"/>
-<polygon fill="#f3168f" stroke="black" points="2632.07,-1368.07 2628.84,-1357.98 2625.08,-1367.88 2632.07,-1368.07"/>
+<polygon fill="#df16f3" stroke="black" points="2632.07,-1368.07 2628.84,-1357.98 2625.08,-1367.88 2632.07,-1368.07"/>
+</g>
+<!-- yaml -->
+<g id="node64" class="node">
+<title>yaml</title><style>.edge>path:hover{stroke-width:8}</style>
+<polygon fill="#c2478a" stroke="black" points="2760.39,-1833.51 2757.39,-1837.51 2736.39,-1837.51 2733.39,-1833.51 2706.39,-1833.51 2706.39,-1797.51 2760.39,-1797.51 2760.39,-1833.51"/>
+<text text-anchor="middle" x="2733.39" y="-1813.01" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">yaml</text>
+</g>
+<!-- yaml&#45;&gt;cookiecutter_python_backend_load_config -->
+<g id="edge102" class="edge">
+<title>yaml&#45;&gt;cookiecutter_python_backend_load_config</title><style>.edge>path:hover{stroke-width:8}</style>
+<path fill="none" stroke="black" d="M2760.44,-1810.22C2846.04,-1795.89 3105.39,-1746.39 3105.39,-1672.51 3105.39,-1672.51 3105.39,-1672.51 3105.39,-866.06 3105.39,-779.79 3015.39,-717.09 2952.67,-683.86"/>
+<polygon fill="#c2478a" stroke="black" points="2954.12,-680.67 2943.63,-679.18 2950.9,-686.88 2954.12,-680.67"/>
+</g>
+<!-- yaml&#45;&gt;cookiecutter -->
+<g id="edge101" class="edge">
+<title>yaml&#45;&gt;cookiecutter</title><style>.edge>path:hover{stroke-width:8}</style>
+<path fill="none" stroke="black" d="M2706.28,-1813.45C2631.83,-1810.11 2426.03,-1797.73 2370.39,-1761.51 2347.9,-1746.87 2332.78,-1719.71 2323.98,-1699.23"/>
+<polygon fill="#c2478a" stroke="black" points="2327.15,-1697.75 2320.16,-1689.79 2320.66,-1700.38 2327.15,-1697.75"/>
 </g>
 </g>
 </svg>

--- a/docs/contents/35_development/arch/deps_ktc-mcs_2.svg
+++ b/docs/contents/35_development/arch/deps_ktc-mcs_2.svg
@@ -35,29 +35,29 @@
 <text text-anchor="middle" x="229" y="-1073.07" font-family="Times,serif" font-size="14.00">jinja2</text>
 </g>
 <g id="clust6" class="cluster">
-<title>cluster_poyo</title><style>.edge>path:hover{stroke-width:8}</style>
-<polygon fill="none" stroke="black" points="151,-1893.24 151,-1968.24 221,-1968.24 221,-1893.24 151,-1893.24"/>
-<text text-anchor="middle" x="186" y="-1953.04" font-family="Times,serif" font-size="14.00">poyo</text>
-</g>
-<g id="clust7" class="cluster">
 <title>cluster_questionary</title><style>.edge>path:hover{stroke-width:8}</style>
 <polygon fill="none" stroke="black" points="1918,-1650.39 1918,-1810.03 2042,-1810.03 2042,-1650.39 1918,-1650.39"/>
 <text text-anchor="middle" x="1980" y="-1794.83" font-family="Times,serif" font-size="14.00">questionary</text>
 </g>
-<g id="clust8" class="cluster">
+<g id="clust7" class="cluster">
 <title>cluster_requests</title><style>.edge>path:hover{stroke-width:8}</style>
 <polygon fill="none" stroke="black" points="1913,-1818.03 1913,-1971.45 2027,-1971.45 2027,-1818.03 1913,-1818.03"/>
 <text text-anchor="middle" x="1970" y="-1956.25" font-family="Times,serif" font-size="14.00">requests</text>
 </g>
-<g id="clust9" class="cluster">
+<g id="clust8" class="cluster">
 <title>cluster_requestsfutures</title><style>.edge>path:hover{stroke-width:8}</style>
 <polygon fill="none" stroke="black" points="1618,-1647.17 1618,-1728.6 1910,-1728.6 1910,-1647.17 1618,-1647.17"/>
 <text text-anchor="middle" x="1764" y="-1713.4" font-family="Times,serif" font-size="14.00">requestsfutures</text>
 </g>
-<g id="clust10" class="cluster">
+<g id="clust9" class="cluster">
 <title>cluster_softwarepatterns</title><style>.edge>path:hover{stroke-width:8}</style>
 <polygon fill="none" stroke="black" points="2362,-903.73 2362,-978.73 2502,-978.73 2502,-903.73 2362,-903.73"/>
 <text text-anchor="middle" x="2432" y="-963.53" font-family="Times,serif" font-size="14.00">softwarepatterns</text>
+</g>
+<g id="clust10" class="cluster">
+<title>cluster_yaml</title><style>.edge>path:hover{stroke-width:8}</style>
+<polygon fill="none" stroke="black" points="151,-1893.24 151,-1968.24 221,-1968.24 221,-1893.24 151,-1893.24"/>
+<text text-anchor="middle" x="186" y="-1953.04" font-family="Times,serif" font-size="14.00">yaml</text>
 </g>
 <!-- attr -->
 <g id="node1" class="node">
@@ -976,15 +976,102 @@
 <path fill="none" stroke="black" d="M250.28,-1013.27C254.62,-1008.33 259.54,-1002.84 264.94,-996.94"/>
 <polygon fill="#000000" stroke="black" points="267.79,-999.02 272,-989.3 262.64,-994.27 267.79,-999.02"/>
 </g>
-<!-- poyo -->
+<!-- questionary -->
 <g id="node59" class="node">
-<title>poyo</title><style>.edge>path:hover{stroke-width:8}</style>
-<ellipse fill="#47a1c2" stroke="black" cx="186" cy="-1919.24" rx="27" ry="18"/>
-<text text-anchor="middle" x="186" y="-1916.74" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#000000">poyo</text>
+<title>questionary</title><style>.edge>path:hover{stroke-width:8}</style>
+<ellipse fill="#319cc4" stroke="black" cx="1975" cy="-1676.39" rx="43.62" ry="18"/>
+<text text-anchor="middle" x="1975" y="-1673.89" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#000000">questionary</text>
 </g>
-<!-- poyo&#45;&gt;cookiecutter_python_backend_load_config -->
+<!-- questionary&#45;&gt;cookiecutter_python_handle_dialogs_lib_project_name -->
+<g id="edge78" class="edge">
+<title>questionary&#45;&gt;cookiecutter_python_handle_dialogs_lib_project_name</title><style>.edge>path:hover{stroke-width:8}</style>
+<path fill="none" stroke="black" d="M1959.2,-1650.39C1958.64,-1649.5 1958.06,-1648.59 1957.47,-1647.66"/>
+<polygon fill="#000000" stroke="black" points="1960.41,-1645.76 1952.11,-1639.17 1954.5,-1649.5 1960.41,-1645.76"/>
+</g>
+<!-- questionary_prompt -->
+<g id="node60" class="node">
+<title>questionary_prompt</title><style>.edge>path:hover{stroke-width:8}</style>
+<ellipse fill="#409dc0" stroke="black" cx="1980" cy="-1757.81" rx="53.98" ry="21.43"/>
+<text text-anchor="middle" x="1980" y="-1760.81" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#000000">questionary.</text>
+<text text-anchor="middle" x="1980" y="-1749.81" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#000000">prompt</text>
+</g>
+<!-- questionary_prompt&#45;&gt;questionary -->
 <g id="edge79" class="edge">
-<title>poyo&#45;&gt;cookiecutter_python_backend_load_config</title><style>.edge>path:hover{stroke-width:8}</style>
+<title>questionary_prompt&#45;&gt;questionary</title><style>.edge>path:hover{stroke-width:8}</style>
+<path fill="none" stroke="black" d="M1978.71,-1736.36C1978.11,-1726.74 1977.38,-1715.13 1976.72,-1704.77"/>
+<polygon fill="#000000" stroke="black" points="1980.2,-1704.31 1976.08,-1694.55 1973.22,-1704.75 1980.2,-1704.31"/>
+</g>
+<!-- requests -->
+<g id="node61" class="node">
+<title>requests</title><style>.edge>path:hover{stroke-width:8}</style>
+<ellipse fill="#2444d0" stroke="black" cx="1970" cy="-1844.03" rx="34.96" ry="18"/>
+<text text-anchor="middle" x="1970" y="-1841.53" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">requests</text>
+</g>
+<!-- requests&#45;&gt;cookiecutter_python_backend_hosting_services_handle_hosting_service_check -->
+<g id="edge80" class="edge">
+<title>requests&#45;&gt;cookiecutter_python_backend_hosting_services_handle_hosting_service_check</title><style>.edge>path:hover{stroke-width:8}</style>
+<path fill="none" stroke="black" d="M2027,-1826.42C2034.31,-1822.13 2040.99,-1816.75 2046,-1810.03 2081.49,-1762.42 2062,-1736.77 2062,-1677.39 2062,-1677.39 2062,-1677.39 2062,-1649.31"/>
+<polygon fill="#000000" stroke="black" points="2065.5,-1649.17 2062,-1639.17 2058.5,-1649.17 2065.5,-1649.17"/>
+</g>
+<!-- requests_futures_sessions -->
+<g id="node64" class="node">
+<title>requests_futures_sessions</title><style>.edge>path:hover{stroke-width:8}</style>
+<ellipse fill="#724cb3" stroke="black" cx="1697" cy="-1676.39" rx="71.34" ry="21.43"/>
+<text text-anchor="middle" x="1697" y="-1679.39" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">requests_futures.</text>
+<text text-anchor="middle" x="1697" y="-1668.39" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">sessions</text>
+</g>
+<!-- requests&#45;&gt;requests_futures_sessions -->
+<g id="edge81" class="edge">
+<title>requests&#45;&gt;requests_futures_sessions</title><style>.edge>path:hover{stroke-width:8}</style>
+<path fill="none" stroke="black" d="M1927.54,-1818.03C1922.97,-1815.33 1918.39,-1812.62 1914,-1810.03 1856.02,-1775.71 1838.93,-1766.66 1785.52,-1733.85"/>
+<polygon fill="#000000" stroke="black" points="1787.35,-1730.86 1777,-1728.6 1783.68,-1736.82 1787.35,-1730.86"/>
+</g>
+<!-- requests_exceptions -->
+<g id="node62" class="node">
+<title>requests_exceptions</title><style>.edge>path:hover{stroke-width:8}</style>
+<ellipse fill="#3b56ce" stroke="black" cx="1970" cy="-1919.24" rx="49.49" ry="21.43"/>
+<text text-anchor="middle" x="1970" y="-1922.24" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">requests.</text>
+<text text-anchor="middle" x="1970" y="-1911.24" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">exceptions</text>
+</g>
+<!-- requests_exceptions&#45;&gt;requests -->
+<g id="edge82" class="edge">
+<title>requests_exceptions&#45;&gt;requests</title><style>.edge>path:hover{stroke-width:8}</style>
+<path fill="none" stroke="black" d="M1970,-1897.85C1970,-1889.99 1970,-1880.89 1970,-1872.48"/>
+<polygon fill="#000000" stroke="black" points="1973.5,-1872.34 1970,-1862.34 1966.5,-1872.34 1973.5,-1872.34"/>
+</g>
+<!-- requests_futures -->
+<g id="node63" class="node">
+<title>requests_futures</title><style>.edge>path:hover{stroke-width:8}</style>
+<ellipse fill="#7753b6" stroke="black" cx="1844" cy="-1676.39" rx="57.88" ry="18"/>
+<text text-anchor="middle" x="1844" y="-1673.89" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">requests_futures</text>
+</g>
+<!-- requests_futures&#45;&gt;cookiecutter_python_backend_hosting_services_check_web_hosting_service -->
+<g id="edge83" class="edge">
+<title>requests_futures&#45;&gt;cookiecutter_python_backend_hosting_services_check_web_hosting_service</title><style>.edge>path:hover{stroke-width:8}</style>
+<path fill="none" stroke="black" d="M1849.31,-1647.17C1849.83,-1645.17 1850.34,-1643.17 1850.85,-1641.17"/>
+<polygon fill="#000000" stroke="black" points="1852.27,-1649.73 1851.36,-1639.17 1845.49,-1647.99 1852.27,-1649.73"/>
+</g>
+<!-- software_patterns -->
+<g id="node65" class="node">
+<title>software_patterns</title><style>.edge>path:hover{stroke-width:8}</style>
+<ellipse fill="#df16f3" stroke="black" cx="2431" cy="-929.73" rx="61.44" ry="18"/>
+<text text-anchor="middle" x="2431" y="-927.23" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">software_patterns</text>
+</g>
+<!-- software_patterns&#45;&gt;cookiecutter_python_backend_error_handling_handler_builder -->
+<g id="edge84" class="edge">
+<title>software_patterns&#45;&gt;cookiecutter_python_backend_error_handling_handler_builder</title><style>.edge>path:hover{stroke-width:8}</style>
+<path fill="none" stroke="black" d="M2428.43,-903.73C2420.6,-838.56 2391.77,-660.75 2302,-548.78 2296.67,-542.13 2290.54,-535.94 2283.94,-530.22"/>
+<polygon fill="#000000" stroke="black" points="2285.95,-527.34 2276,-523.71 2281.51,-532.76 2285.95,-527.34"/>
+</g>
+<!-- yaml -->
+<g id="node66" class="node">
+<title>yaml</title><style>.edge>path:hover{stroke-width:8}</style>
+<ellipse fill="#c2478a" stroke="black" cx="186" cy="-1919.24" rx="27" ry="18"/>
+<text text-anchor="middle" x="186" y="-1916.74" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">yaml</text>
+</g>
+<!-- yaml&#45;&gt;cookiecutter_python_backend_load_config -->
+<g id="edge86" class="edge">
+<title>yaml&#45;&gt;cookiecutter_python_backend_load_config</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M186.89,-1893.24C187.62,-1871.31 188.6,-1838.56 189,-1810.03 189.45,-1777.4 189.98,-1769.22 189,-1736.6 185.67,-1625.16 174,-1597.69 174,-1486.2 174,-1486.2 174,-1486.2 174,-928.73 174,-913.45 211.72,-886.07 263.27,-855.79"/>
 <polygon fill="#000000" stroke="black" points="265.12,-858.76 272,-850.71 261.6,-852.71 265.12,-858.76"/>
 </g>
@@ -994,98 +1081,11 @@
 <polygon fill="#d5e722" stroke="black" points="179.5,-1775.81 176.5,-1779.81 155.5,-1779.81 152.5,-1775.81 102.5,-1775.81 102.5,-1739.81 179.5,-1739.81 179.5,-1775.81"/>
 <text text-anchor="middle" x="141" y="-1755.31" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#000000">cookiecutter</text>
 </g>
-<!-- poyo&#45;&gt;cookiecutter -->
-<g id="edge78" class="edge">
-<title>poyo&#45;&gt;cookiecutter</title><style>.edge>path:hover{stroke-width:8}</style>
+<!-- yaml&#45;&gt;cookiecutter -->
+<g id="edge85" class="edge">
+<title>yaml&#45;&gt;cookiecutter</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M178.94,-1893.25C170.69,-1864 157.08,-1815.78 148.6,-1785.73"/>
 <polygon fill="#000000" stroke="black" points="151.89,-1784.5 145.8,-1775.83 145.15,-1786.4 151.89,-1784.5"/>
-</g>
-<!-- questionary -->
-<g id="node60" class="node">
-<title>questionary</title><style>.edge>path:hover{stroke-width:8}</style>
-<ellipse fill="#314bc4" stroke="black" cx="1975" cy="-1676.39" rx="43.62" ry="18"/>
-<text text-anchor="middle" x="1975" y="-1673.89" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">questionary</text>
-</g>
-<!-- questionary&#45;&gt;cookiecutter_python_handle_dialogs_lib_project_name -->
-<g id="edge80" class="edge">
-<title>questionary&#45;&gt;cookiecutter_python_handle_dialogs_lib_project_name</title><style>.edge>path:hover{stroke-width:8}</style>
-<path fill="none" stroke="black" d="M1959.2,-1650.39C1958.64,-1649.5 1958.06,-1648.59 1957.47,-1647.66"/>
-<polygon fill="#000000" stroke="black" points="1960.41,-1645.76 1952.11,-1639.17 1954.5,-1649.5 1960.41,-1645.76"/>
-</g>
-<!-- questionary_prompt -->
-<g id="node61" class="node">
-<title>questionary_prompt</title><style>.edge>path:hover{stroke-width:8}</style>
-<ellipse fill="#4057c0" stroke="black" cx="1980" cy="-1757.81" rx="53.98" ry="21.43"/>
-<text text-anchor="middle" x="1980" y="-1760.81" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">questionary.</text>
-<text text-anchor="middle" x="1980" y="-1749.81" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">prompt</text>
-</g>
-<!-- questionary_prompt&#45;&gt;questionary -->
-<g id="edge81" class="edge">
-<title>questionary_prompt&#45;&gt;questionary</title><style>.edge>path:hover{stroke-width:8}</style>
-<path fill="none" stroke="black" d="M1978.71,-1736.36C1978.11,-1726.74 1977.38,-1715.13 1976.72,-1704.77"/>
-<polygon fill="#000000" stroke="black" points="1980.2,-1704.31 1976.08,-1694.55 1973.22,-1704.75 1980.2,-1704.31"/>
-</g>
-<!-- requests -->
-<g id="node62" class="node">
-<title>requests</title><style>.edge>path:hover{stroke-width:8}</style>
-<ellipse fill="#6324d0" stroke="black" cx="1970" cy="-1844.03" rx="34.96" ry="18"/>
-<text text-anchor="middle" x="1970" y="-1841.53" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">requests</text>
-</g>
-<!-- requests&#45;&gt;cookiecutter_python_backend_hosting_services_handle_hosting_service_check -->
-<g id="edge82" class="edge">
-<title>requests&#45;&gt;cookiecutter_python_backend_hosting_services_handle_hosting_service_check</title><style>.edge>path:hover{stroke-width:8}</style>
-<path fill="none" stroke="black" d="M2027,-1826.42C2034.31,-1822.13 2040.99,-1816.75 2046,-1810.03 2081.49,-1762.42 2062,-1736.77 2062,-1677.39 2062,-1677.39 2062,-1677.39 2062,-1649.31"/>
-<polygon fill="#000000" stroke="black" points="2065.5,-1649.17 2062,-1639.17 2058.5,-1649.17 2065.5,-1649.17"/>
-</g>
-<!-- requests_futures_sessions -->
-<g id="node65" class="node">
-<title>requests_futures_sessions</title><style>.edge>path:hover{stroke-width:8}</style>
-<ellipse fill="#a94cb3" stroke="black" cx="1697" cy="-1676.39" rx="71.34" ry="21.43"/>
-<text text-anchor="middle" x="1697" y="-1679.39" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">requests_futures.</text>
-<text text-anchor="middle" x="1697" y="-1668.39" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">sessions</text>
-</g>
-<!-- requests&#45;&gt;requests_futures_sessions -->
-<g id="edge83" class="edge">
-<title>requests&#45;&gt;requests_futures_sessions</title><style>.edge>path:hover{stroke-width:8}</style>
-<path fill="none" stroke="black" d="M1927.54,-1818.03C1922.97,-1815.33 1918.39,-1812.62 1914,-1810.03 1856.02,-1775.71 1838.93,-1766.66 1785.52,-1733.85"/>
-<polygon fill="#000000" stroke="black" points="1787.35,-1730.86 1777,-1728.6 1783.68,-1736.82 1787.35,-1730.86"/>
-</g>
-<!-- requests_exceptions -->
-<g id="node63" class="node">
-<title>requests_exceptions</title><style>.edge>path:hover{stroke-width:8}</style>
-<ellipse fill="#713bce" stroke="black" cx="1970" cy="-1919.24" rx="49.49" ry="21.43"/>
-<text text-anchor="middle" x="1970" y="-1922.24" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">requests.</text>
-<text text-anchor="middle" x="1970" y="-1911.24" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">exceptions</text>
-</g>
-<!-- requests_exceptions&#45;&gt;requests -->
-<g id="edge84" class="edge">
-<title>requests_exceptions&#45;&gt;requests</title><style>.edge>path:hover{stroke-width:8}</style>
-<path fill="none" stroke="black" d="M1970,-1897.85C1970,-1889.99 1970,-1880.89 1970,-1872.48"/>
-<polygon fill="#000000" stroke="black" points="1973.5,-1872.34 1970,-1862.34 1966.5,-1872.34 1973.5,-1872.34"/>
-</g>
-<!-- requests_futures -->
-<g id="node64" class="node">
-<title>requests_futures</title><style>.edge>path:hover{stroke-width:8}</style>
-<ellipse fill="#ad53b6" stroke="black" cx="1844" cy="-1676.39" rx="57.88" ry="18"/>
-<text text-anchor="middle" x="1844" y="-1673.89" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">requests_futures</text>
-</g>
-<!-- requests_futures&#45;&gt;cookiecutter_python_backend_hosting_services_check_web_hosting_service -->
-<g id="edge85" class="edge">
-<title>requests_futures&#45;&gt;cookiecutter_python_backend_hosting_services_check_web_hosting_service</title><style>.edge>path:hover{stroke-width:8}</style>
-<path fill="none" stroke="black" d="M1849.31,-1647.17C1849.83,-1645.17 1850.34,-1643.17 1850.85,-1641.17"/>
-<polygon fill="#000000" stroke="black" points="1852.27,-1649.73 1851.36,-1639.17 1845.49,-1647.99 1852.27,-1649.73"/>
-</g>
-<!-- software_patterns -->
-<g id="node66" class="node">
-<title>software_patterns</title><style>.edge>path:hover{stroke-width:8}</style>
-<ellipse fill="#f3168f" stroke="black" cx="2431" cy="-929.73" rx="61.44" ry="18"/>
-<text text-anchor="middle" x="2431" y="-927.23" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">software_patterns</text>
-</g>
-<!-- software_patterns&#45;&gt;cookiecutter_python_backend_error_handling_handler_builder -->
-<g id="edge86" class="edge">
-<title>software_patterns&#45;&gt;cookiecutter_python_backend_error_handling_handler_builder</title><style>.edge>path:hover{stroke-width:8}</style>
-<path fill="none" stroke="black" d="M2428.43,-903.73C2420.6,-838.56 2391.77,-660.75 2302,-548.78 2296.67,-542.13 2290.54,-535.94 2283.94,-530.22"/>
-<polygon fill="#000000" stroke="black" points="2285.95,-527.34 2276,-523.71 2281.51,-532.76 2285.95,-527.34"/>
 </g>
 <!-- cookiecutter&#45;&gt;cookiecutter_python_backend_generator_generator -->
 <g id="edge3" class="edge">

--- a/docs/contents/35_development/arch/deps_ktc.svg
+++ b/docs/contents/35_development/arch/deps_ktc.svg
@@ -1027,113 +1027,113 @@
 <path fill="none" stroke="black" d="M273.37,-1020.94C277.77,-1014.96 283.27,-1007.64 289.76,-999.28"/>
 <polygon fill="#53b69b" stroke="black" points="292.59,-1001.35 296,-991.32 287.08,-997.03 292.59,-1001.35"/>
 </g>
-<!-- poyo -->
-<g id="node60" class="node">
-<title>poyo</title><style>.edge>path:hover{stroke-width:8}</style>
-<polygon fill="#47a1c2" stroke="black" points="303,-1899.17 300,-1903.17 279,-1903.17 276,-1899.17 249,-1899.17 249,-1863.17 303,-1863.17 303,-1899.17"/>
-<text text-anchor="middle" x="276" y="-1878.67" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#000000">poyo</text>
-</g>
-<!-- poyo&#45;&gt;cookiecutter_python_backend_load_config -->
-<g id="edge91" class="edge">
-<title>poyo&#45;&gt;cookiecutter_python_backend_load_config</title><style>.edge>path:hover{stroke-width:8}</style>
-<path fill="none" stroke="black" d="M260.65,-1863.02C223.17,-1819.27 130,-1698.63 130,-1580.18 130,-1580.18 130,-1580.18 130,-928.73 130,-861.5 125.41,-831.88 172,-783.42 201.96,-752.25 245.76,-734.62 286.11,-724.64"/>
-<polygon fill="#47a1c2" stroke="black" points="287.06,-728.01 296,-722.32 285.47,-721.19 287.06,-728.01"/>
-</g>
-<!-- poyo&#45;&gt;cookiecutter -->
-<g id="edge90" class="edge">
-<title>poyo&#45;&gt;cookiecutter</title><style>.edge>path:hover{stroke-width:8}</style>
-<path fill="none" stroke="black" d="M303.28,-1877.99C411.95,-1868.93 824.13,-1831.19 1155,-1755.17 1156.47,-1754.84 1157.96,-1754.48 1159.46,-1754.1"/>
-<polygon fill="#47a1c2" stroke="black" points="1160.7,-1757.39 1169.42,-1751.38 1158.85,-1750.64 1160.7,-1757.39"/>
-</g>
 <!-- questionary -->
-<g id="node61" class="node">
+<g id="node60" class="node">
 <title>questionary</title><style>.edge>path:hover{stroke-width:8}</style>
-<polygon fill="#314bc4" stroke="black" points="531,-1683.17 528,-1687.17 507,-1687.17 504,-1683.17 457,-1683.17 457,-1647.17 531,-1647.17 531,-1683.17"/>
-<text text-anchor="middle" x="494" y="-1662.67" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">questionary</text>
+<polygon fill="#319cc4" stroke="black" points="531,-1683.17 528,-1687.17 507,-1687.17 504,-1683.17 457,-1683.17 457,-1647.17 531,-1647.17 531,-1683.17"/>
+<text text-anchor="middle" x="494" y="-1662.67" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#000000">questionary</text>
 </g>
 <!-- questionary&#45;&gt;cookiecutter_python_handle_dialogs_lib_project_name -->
-<g id="edge92" class="edge">
+<g id="edge90" class="edge">
 <title>questionary&#45;&gt;cookiecutter_python_handle_dialogs_lib_project_name</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M494,-1647.11C494,-1646.96 494,-1646.81 494,-1646.66"/>
-<polygon fill="#314bc4" stroke="black" points="497.5,-1649.17 494,-1639.17 490.5,-1649.17 497.5,-1649.17"/>
+<polygon fill="#319cc4" stroke="black" points="497.5,-1649.17 494,-1639.17 490.5,-1649.17 497.5,-1649.17"/>
 </g>
 <!-- requests -->
-<g id="node62" class="node">
+<g id="node61" class="node">
 <title>requests</title><style>.edge>path:hover{stroke-width:8}</style>
-<polygon fill="#6324d0" stroke="black" points="1638.5,-1827.17 1635.5,-1831.17 1614.5,-1831.17 1611.5,-1827.17 1579.5,-1827.17 1579.5,-1791.17 1638.5,-1791.17 1638.5,-1827.17"/>
+<polygon fill="#2444d0" stroke="black" points="1638.5,-1827.17 1635.5,-1831.17 1614.5,-1831.17 1611.5,-1827.17 1579.5,-1827.17 1579.5,-1791.17 1638.5,-1791.17 1638.5,-1827.17"/>
 <text text-anchor="middle" x="1609" y="-1806.67" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">requests</text>
 </g>
 <!-- requests&#45;&gt;cookiecutter_python_backend_hosting_services_handle_hosting_service_check -->
-<g id="edge93" class="edge">
+<g id="edge91" class="edge">
 <title>requests&#45;&gt;cookiecutter_python_backend_hosting_services_handle_hosting_service_check</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M1609,-1791.13C1609,-1764.47 1609,-1711.29 1609,-1666.17 1609,-1666.17 1609,-1666.17 1609,-1649.5"/>
-<polygon fill="#6324d0" stroke="black" points="1612.5,-1649.17 1609,-1639.17 1605.5,-1649.17 1612.5,-1649.17"/>
+<polygon fill="#2444d0" stroke="black" points="1612.5,-1649.17 1609,-1639.17 1605.5,-1649.17 1612.5,-1649.17"/>
 </g>
 <!-- requests&#45;&gt;cookiecutter_python_backend_post_main -->
-<g id="edge94" class="edge">
+<g id="edge92" class="edge">
 <title>requests&#45;&gt;cookiecutter_python_backend_post_main</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M1638.79,-1808.34C1769.03,-1808.29 2282,-1799.62 2282,-1666.17 2282,-1666.17 2282,-1666.17 2282,-1649.5"/>
-<polygon fill="#6324d0" stroke="black" points="2285.5,-1649.17 2282,-1639.17 2278.5,-1649.17 2285.5,-1649.17"/>
+<polygon fill="#2444d0" stroke="black" points="2285.5,-1649.17 2282,-1639.17 2278.5,-1649.17 2285.5,-1649.17"/>
 </g>
 <!-- requestsfutures -->
-<g id="node63" class="node">
+<g id="node62" class="node">
 <title>requestsfutures</title><style>.edge>path:hover{stroke-width:8}</style>
-<polygon fill="#ad53b6" stroke="black" points="1580.5,-1683.17 1577.5,-1687.17 1556.5,-1687.17 1553.5,-1683.17 1487.5,-1683.17 1487.5,-1647.17 1580.5,-1647.17 1580.5,-1683.17"/>
+<polygon fill="#7753b6" stroke="black" points="1580.5,-1683.17 1577.5,-1687.17 1556.5,-1687.17 1553.5,-1683.17 1487.5,-1683.17 1487.5,-1647.17 1580.5,-1647.17 1580.5,-1683.17"/>
 <text text-anchor="middle" x="1534" y="-1662.67" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">requestsfutures</text>
 </g>
 <!-- requests&#45;&gt;requestsfutures -->
-<g id="edge95" class="edge">
+<g id="edge93" class="edge">
 <title>requests&#45;&gt;requestsfutures</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M1599.95,-1791.05C1587,-1766.53 1563.07,-1721.21 1547.87,-1692.43"/>
-<polygon fill="#6324d0" stroke="black" points="1550.84,-1690.57 1543.08,-1683.36 1544.65,-1693.84 1550.84,-1690.57"/>
+<polygon fill="#2444d0" stroke="black" points="1550.84,-1690.57 1543.08,-1683.36 1544.65,-1693.84 1550.84,-1690.57"/>
 </g>
 <!-- requestsfutures&#45;&gt;cookiecutter_python_backend_hosting_services_check_web_hosting_service -->
-<g id="edge96" class="edge">
+<g id="edge94" class="edge">
 <title>requestsfutures&#45;&gt;cookiecutter_python_backend_hosting_services_check_web_hosting_service</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M1534.69,-1647.11C1534.69,-1646.96 1534.7,-1646.81 1534.71,-1646.66"/>
-<polygon fill="#ad53b6" stroke="black" points="1538.1,-1649.3 1535.01,-1639.17 1531.11,-1649.02 1538.1,-1649.3"/>
+<polygon fill="#7753b6" stroke="black" points="1538.1,-1649.3 1535.01,-1639.17 1531.11,-1649.02 1538.1,-1649.3"/>
 </g>
 <!-- softwarepatterns -->
-<g id="node64" class="node">
+<g id="node63" class="node">
 <title>softwarepatterns</title><style>.edge>path:hover{stroke-width:8}</style>
-<polygon fill="#f3168f" stroke="black" points="562.5,-1827.17 559.5,-1831.17 538.5,-1831.17 535.5,-1827.17 463.5,-1827.17 463.5,-1791.17 562.5,-1791.17 562.5,-1827.17"/>
+<polygon fill="#df16f3" stroke="black" points="562.5,-1827.17 559.5,-1831.17 538.5,-1831.17 535.5,-1827.17 463.5,-1827.17 463.5,-1791.17 562.5,-1791.17 562.5,-1827.17"/>
 <text text-anchor="middle" x="513" y="-1806.67" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">softwarepatterns</text>
 </g>
 <!-- softwarepatterns&#45;&gt;cookiecutter_python_backend_error_handling_handler_builder -->
-<g id="edge97" class="edge">
+<g id="edge95" class="edge">
 <title>softwarepatterns&#45;&gt;cookiecutter_python_backend_error_handling_handler_builder</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M463.42,-1803.93C389.7,-1796.86 255.49,-1780.86 215,-1755.17 197.9,-1744.33 92,-1596.91 92,-1580.18 92,-1580.18 92,-1580.18 92,-709.65 92,-583.62 175.7,-559.11 285.95,-545.42"/>
-<polygon fill="#f3168f" stroke="black" points="286.49,-548.88 296,-544.2 285.65,-541.93 286.49,-548.88"/>
+<polygon fill="#df16f3" stroke="black" points="286.49,-548.88 296,-544.2 285.65,-541.93 286.49,-548.88"/>
 </g>
 <!-- softwarepatterns&#45;&gt;cookiecutter_python_backend_generator_generator -->
-<g id="edge98" class="edge">
+<g id="edge96" class="edge">
 <title>softwarepatterns&#45;&gt;cookiecutter_python_backend_generator_generator</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M463.2,-1798.51C367.66,-1778.53 168,-1729.25 168,-1666.17 168,-1666.17 168,-1666.17 168,-928.73 168,-857.8 177.3,-826.04 234,-783.42 252.71,-769.35 269.75,-760.87 285.99,-755.98"/>
-<polygon fill="#f3168f" stroke="black" points="287.2,-759.28 296,-753.38 285.44,-752.5 287.2,-759.28"/>
+<polygon fill="#df16f3" stroke="black" points="287.2,-759.28 296,-753.38 285.44,-752.5 287.2,-759.28"/>
 </g>
 <!-- softwarepatterns&#45;&gt;cookiecutter_python_backend_hosting_services_web_hosting_service -->
-<g id="edge99" class="edge">
+<g id="edge97" class="edge">
 <title>softwarepatterns&#45;&gt;cookiecutter_python_backend_hosting_services_web_hosting_service</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M479.94,-1790.98C441.14,-1768.14 382,-1723.87 382,-1666.17 382,-1666.17 382,-1666.17 382,-1649.5"/>
-<polygon fill="#f3168f" stroke="black" points="385.5,-1649.17 382,-1639.17 378.5,-1649.17 385.5,-1649.17"/>
+<polygon fill="#df16f3" stroke="black" points="385.5,-1649.17 382,-1639.17 378.5,-1649.17 385.5,-1649.17"/>
 </g>
 <!-- softwarepatterns&#45;&gt;cookiecutter_python_backend_proxy -->
-<g id="edge100" class="edge">
+<g id="edge98" class="edge">
 <title>softwarepatterns&#45;&gt;cookiecutter_python_backend_proxy</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M562.63,-1792C641.26,-1765.61 798.69,-1709.56 926.83,-1643.92"/>
-<polygon fill="#f3168f" stroke="black" points="928.72,-1646.88 936,-1639.17 925.51,-1640.66 928.72,-1646.88"/>
+<polygon fill="#df16f3" stroke="black" points="928.72,-1646.88 936,-1639.17 925.51,-1640.66 928.72,-1646.88"/>
 </g>
 <!-- softwarepatterns&#45;&gt;cookiecutter_python_backend_user_config_proxy -->
-<g id="edge101" class="edge">
+<g id="edge99" class="edge">
 <title>softwarepatterns&#45;&gt;cookiecutter_python_backend_user_config_proxy</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M562.63,-1801.85C691.2,-1784.39 1030.89,-1731.19 1115.28,-1646.65"/>
-<polygon fill="#f3168f" stroke="black" points="1117.92,-1648.95 1122,-1639.17 1112.71,-1644.27 1117.92,-1648.95"/>
+<polygon fill="#df16f3" stroke="black" points="1117.92,-1648.95 1122,-1639.17 1112.71,-1644.27 1117.92,-1648.95"/>
 </g>
 <!-- softwarepatterns&#45;&gt;cookiecutter_python_handle_dialogs_dialog -->
-<g id="edge102" class="edge">
+<g id="edge100" class="edge">
 <title>softwarepatterns&#45;&gt;cookiecutter_python_handle_dialogs_dialog</title><style>.edge>path:hover{stroke-width:8}</style>
 <path fill="none" stroke="black" d="M546.31,-1791.04C585.41,-1768.27 645,-1724.07 645,-1666.17 645,-1666.17 645,-1666.17 645,-1649.5"/>
-<polygon fill="#f3168f" stroke="black" points="648.5,-1649.17 645,-1639.17 641.5,-1649.17 648.5,-1649.17"/>
+<polygon fill="#df16f3" stroke="black" points="648.5,-1649.17 645,-1639.17 641.5,-1649.17 648.5,-1649.17"/>
+</g>
+<!-- yaml -->
+<g id="node64" class="node">
+<title>yaml</title><style>.edge>path:hover{stroke-width:8}</style>
+<polygon fill="#c2478a" stroke="black" points="303,-1899.17 300,-1903.17 279,-1903.17 276,-1899.17 249,-1899.17 249,-1863.17 303,-1863.17 303,-1899.17"/>
+<text text-anchor="middle" x="276" y="-1878.67" font-family="Helvetica,sans-Serif" font-size="10.00" fill="#ffffff">yaml</text>
+</g>
+<!-- yaml&#45;&gt;cookiecutter_python_backend_load_config -->
+<g id="edge102" class="edge">
+<title>yaml&#45;&gt;cookiecutter_python_backend_load_config</title><style>.edge>path:hover{stroke-width:8}</style>
+<path fill="none" stroke="black" d="M260.65,-1863.02C223.17,-1819.27 130,-1698.63 130,-1580.18 130,-1580.18 130,-1580.18 130,-928.73 130,-861.5 125.41,-831.88 172,-783.42 201.96,-752.25 245.76,-734.62 286.11,-724.64"/>
+<polygon fill="#c2478a" stroke="black" points="287.06,-728.01 296,-722.32 285.47,-721.19 287.06,-728.01"/>
+</g>
+<!-- yaml&#45;&gt;cookiecutter -->
+<g id="edge101" class="edge">
+<title>yaml&#45;&gt;cookiecutter</title><style>.edge>path:hover{stroke-width:8}</style>
+<path fill="none" stroke="black" d="M303.28,-1877.99C411.95,-1868.93 824.13,-1831.19 1155,-1755.17 1156.47,-1754.84 1157.96,-1754.48 1159.46,-1754.1"/>
+<polygon fill="#c2478a" stroke="black" points="1160.7,-1757.39 1169.42,-1751.38 1158.85,-1750.64 1160.7,-1757.39"/>
 </g>
 </g>
 </svg>

--- a/docs/contents/35_development/dependencies.rst
+++ b/docs/contents/35_development/dependencies.rst
@@ -1,0 +1,90 @@
+===================================
+Dependencies to 3rd Party Libraries
+===================================
+
+.. Description of what is this Page
+Here you can find information about how we derived our software 3rd-party
+module dependencies, to ensure diverse environments are compatible with our
+`Python Generator`.
+
+Module Dependencies
+===================
+
+.. Description of what is this Section
+| We set the **allowed Python runtime** versions from 3.8 to 3.12.
+| We Stress Test our distribution on all 5 versions in the range, with the goal to:
+
+- allow diverse environments to run our `Python Generator`
+- increase the guarantee that our code is **bug-free** on the most common Python versions
+
+This is also a way of saying, sth along the lines of:
+
+- "I believe my code is better to be run on Python 3.8 to 3.12"
+- if outside of this range, it might not work, or it might work, but we don't guarantee it
+
+The 3rd-party module dependencies are kept to minimum, and they where chosen
+with **criteria:**
+
+- **Single Responsibility** - to keep the codebase clean
+- **Small footprint** - to keep the Docker image size small
+- **Adoption** - to ensure the libraries are widely adopted
+- **Python compatibility** - to ensure diverse environments are compatible with our `Python Generator`
+
+| Dependencies are declared (ie in *pyproject.toml*) and we distinguish the Prod/Main ones from the optional
+
+| Prod Dependencies are declared (ie in `pyproject.toml` file), for 3 main reasons:
+
+- your app code is directly using the 3rd-party module (runtime dependency)
+- a 3rd-party module's transient dependency is used by your app code 
+- a 3rd-party module's transient dependency was found to have issues for certain versions
+
+    - restricting the compatibility of your app with other 3rd-party modules
+    - having a security vulnerability
+    - issue can be causing the tests to fail
+    - having a bug that affects the functionality of your app
+
+For example, `cookiecutter` is our primary dependency, since our Generator is practically a wrapper around it.
+
+We trust the `cookiecutter` team to deliver their Sem Ver promise. We also trust the `jinja2` team to deliver their Sem Ver promise.
+
+So we first addition of `cookiecutter` (after migration from poetry to uv) we do:
+
+.. code-block:: bash
+
+    uv add 'cookiecutter >=1.0.0, <2.0.0'
+
+
+.. Subsectoin with name Breakdown of Dependencies
+Breakdown of Prod Dependencies
+==============================
+
+.. rst table with columns: Name, version Range, Comment, Interface Surface, Reason
+
+.. TODO implement pydeps based solutions that parses number of edges in the depth-1 all-deps graph
+.. TODO the we have the ability to continuous track the 3rd-party libs number of imports to aguge on the interfacing surface area
+.. TODO with our codebase
+
+questionary | | only used in one module but critical since it handles interactive cli (although I am pretty sure there many aleternatives open-sourced)
+
+| **NOTE:** request-futures is wrapper for concurrent.requests which is high-level interface for async callables
+So we can elminate it and use "vanilla async await where needed and event loop managemtn in the code"
+
+**request-futures** | | used in one module but critical since it handles async requests
+**requests** is only used by our app, to impoer an exception and catch it. we can also eliminate this probably
+
+click | | we use "3 components" from it: the sdk to declare our CLI, one exception to register in our app exceptions, one "console echo" callable (i guess for the coloring) | it is a trusted piece of software with a large adoption
+
+attrs | | honestly all our classes are in attrs, but it glorifies the Single Responsibility principal, and actual classes are completely intact. | it is a trusted piece of software with a large adoption
+
+yaml | | our prefered lib for yaml (same as cookiecutter uses), only used in one module for "correct initialization of CLI wizard"
+if we ant to remove this we use default cli wizard initiaqlization (point;ess since current cookiecutter also uses it and it is yaml lib! (should be "pure" module) )
+gitpython | | only used **in one module** in the post gen hook to support optional **git init** ON/Off switch
+
+
++------------------+---------------------+--------------------+-------------------------------------------------------------------------------------+
+| Name             | Version Range       | Interface Surface  | Reason                                                                              |
++==================+=====================+====================+=====================================================================================+
+| ``cookiecutter`` | >=1.0.0, <2.0.0     | big                | We trust that they respect semver, so inside the range there are no backwards       |
+|                  |                     |                    | incompatible changes.                                                              |
++------------------+---------------------+--------------------+-------------------------------------------------------------------------------------+
+| jinja2  | | small, but important since we use to manually render the cookie context (required in interactive mode by cli wizard       |

--- a/docs/contents/35_development/index.rst
+++ b/docs/contents/35_development/index.rst
@@ -5,6 +5,15 @@ Developer's Corner
 Here we present the **Software Architecture** and offer **Guides** on how to
 leverage the **CI/CD** to do various Development Operations, in a **GitOps** way.
 
+Architecture
+============
+
+.. toctree::
+   :maxdepth: 1
+
+   architecture
+   dependencies
+
 CI/CD Pipeline
 ==============
 
@@ -13,13 +22,6 @@ CI/CD Pipeline
 
    ci_cd_pipeline
 
-Architecture
-============
-
-.. toctree::
-   :maxdepth: 1
-
-   architecture
 
 GitOps Guides
 =============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,3 +176,9 @@ explicit-only = [
     "slow",
     "requires_uv",
 ]
+
+
+
+[tool.isort]
+profile = 'black'
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,73 +1,48 @@
-# BUILD
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-# Poetry
+### NEW ###
+# [project]
+# name = "cookiecutter-python"
+### ... ###
 
-# Information required for building (sdist/wheel)
-## Also renders on pypi as 'subtitle'
+### OLD ###
 [tool.poetry]
 name = "cookiecutter_python"
+### ... ###
+
 version = "2.5.0"
 description = "1-click Generator of Python Project, from Template with streamlined \"DevOps\" using a powerful CI/CD Pipeline."
+readme = "README.rst"
+license = "AGPL-3.0-only"
+
+# OLD
 authors = ["Konstantinos Lampridis <k.lampridis@hotmail.com>"]
 maintainers = ["Konstantinos Lampridis <k.lampridis@hotmail.com>"]
-license = "AGPL-3.0-only"
-readme = "README.rst"
 
-homepage = "https://github.com/boromir674/cookiecutter-python-package"
-repository = "https://github.com/boromir674/cookiecutter-python-package"
-documentation = "https://python-package-generator.readthedocs.io/"
-
-keywords = [
-    "python package generator",
-    "python package template",
-    "cookiecutter",
-    "python package",
-    "automation"
-]
-classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "Intended Audience :: End Users/Desktop",
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU Affero General Public License v3",
-    "Natural Language :: English",
-    "Operating System :: Unix",
-    "Operating System :: POSIX :: Linux",
-    "Operating System :: MacOS",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Topic :: Software Development",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: System :: Software Distribution",
-    "Typing :: Typed"
-]
-
-packages = [
-    { include = "cookiecutter_python", from = "src" },
-]
+# NEW
+# authors = [{"name" = "Konstantinos Lampridis", "email" = "k.lampridis@hotmail.com"}]
+# maintainers = [{"name" = "Konstantinos Lampridis", "email" = "k.lampridis@hotmail.com"}]
 
 include = [
     { path = "tests", format = "sdist" },
-    { path = "docs/**/*.rst", format = "sdist" },
-    { path = "docs/conf.py", format = "sdist" },
+    { path = "tests/data", format = "sdist" },
+    { path = "tests/generator_defaults_shift", format = "sdist" },
+    # { path = "docs/**/*.rst", format = "sdist" },
+    # { path = "docs/conf.py", format = "sdist" },
     { path = "src/**/*.typed", format = "sdist" },
     { path = "src/stubs/*.pyi", format = "sdist" },
+    # TODO: find how to distribute cookiecutter-python-types
+    # because path = "src/stubs/*.pyi" does not work
     "pyproject.toml",
     "LICENSE",
     "README.rst",
     "CONTRIBUTING.md",
     "CHANGELOG.rst",
+    # "Dockerfile",
 ]
-
 exclude = [
     "docs/*",
     "requirements/*",
@@ -84,186 +59,119 @@ exclude = [
     ".travis.yml"
 ]
 
-
 [tool.poetry.scripts]
 generate-python = 'cookiecutter_python.cli:main'
 
-[tool.poetry.dependencies]
-python = ">=3.7,<3.13"
-click = "^8"
-cookiecutter = "^2.1.1"
-software-patterns = "^1.3.0"
-requests-futures = "^1.0.0"
-gitpython = { version = "^3.1.30", python = ">=3.7,<3.13" }
-questionary = "^1.10.0"
-attrs = "^21.4.0"
-pyyaml = "^6.0"
+
+[project]
+authors = [
+    {name = "Konstantinos Lampridis", email = "k.lampridis@hotmail.com"},
+]
+maintainers = [
+    {name = "Konstantinos Lampridis", email = "k.lampridis@hotmail.com"},
+]
+license = {text = "AGPL-3.0-only"}
+
+name = "cookiecutter_python"
+version = "2.5.0"
+description = "1-click Generator of Python Project, from Template with streamlined \"DevOps\" using a powerful CI/CD Pipeline."
+readme = "README.rst"
+# keywords = []
+# classifiers = []
 
 
-# Caret requirements allow SemVer compatible updates to a specified version. An update is allowed if the new version number does not modify the left-most non-zero digit in the major, minor, patch grouping. For instance, if we previously ran poetry add requests@^2.13.0 and wanted to update the library and ran poetry update requests, poetry would update us to version 2.14.0 if it was available, but would not update us to 3.0.0. If instead we had specified the version string as ^0.1.13, poetry would update to 0.1.14 but not 0.2.0. 0.0.x is not considered compatible with any other version.
-# REQUIREMENT  VERSIONS ALLOWED
-# ^1.2.3	   >=1.2.3 <2.0.0
-# ^1.2	       >=1.2.0 <2.0.0
-# ^1	       >=1.0.0 <2.0.0
-# ^0.2.3	   >=0.2.3 <0.3.0
-# ^0.0.3	   >=0.0.3 <0.0.4
-# ^0.0	       >=0.0.0 <0.1.0
-# ^0	       >=0.0.0 <1.0.0
-# "~" is the more conservative compared to "^"
-# Tilde requirements specify a minimal version with some ability to update. If you specify a major, minor, and patch version or only a major and minor version, only patch-level changes are allowed. If you only specify a major version, then minor- and patch-level changes are allowed.
-# REQUIREMENT  VERSIONS ALLOWED
-# ~1.2.3	   >=1.2.3 <1.3.0
-# ~1.2	       >=1.2.0 <1.3.0
-# ~1	       >=1.0.0 <2.0.0
+#### ALLOWED PYTHON ####
+requires-python = ">=3.8, <3.13"
 
-# Test: packages imported in test code and packages required for the "test runner"
-pytest = { version = "^7.2.0", optional = true, python = ">=3.7,<3.13" }
-pytest-object-getter = { version = "^1.0.1", optional = true }
-pytest-click = { version = "~= 1.1.0", optional = true }
-pytest-cov = { version = ">= 2.12", optional = true }
-pytest-explicit = { version = "~= 1.0.1", optional = true }
-pytest-xdist = { version = ">= 1.34", optional = true }
-pytest-run-subprocess = { version = "== 0.9.0", optional = true }
-pytest-requests-futures = { version = "== 0.9.0", optional = true }
+## Prod DEPENDENCIES ##
+dependencies = [
+    "click<9,>=8",
+    "cookiecutter<3.0.0,>=2.1.1",
+    "software-patterns<2.0.0,>=1.3.0",
+    "requests-futures<2.0.0,>=1.0.0",
+    "gitpython<4.0.0,>=3.1.30; python_version < \"3.13\" and python_version >= \"3.7\"",
+    "questionary<2.0.0,>=1.10.0",
+    "attrs<22.0.0,>=21.4.0",
+    "pyyaml<7.0,>=6.0",
+    "rich<14.0.0,>=13.0.0; python_version < \"3.13\" and python_version >= \"3.7\"",
+    "jinja2-time<1.0.0,>=0.2.0",
+    "packaging<23,>=22",
+]
 
-# Docs: development and build dependencies
-sphinx = { version = "~= 6.0", optional = true, python = ">=3.8,<3.13" }
-sphinx-autodoc-typehints = { version = ">= 1.10", optional = true }
-sphinx-rtd-theme = { version = "== 0.5.0", optional = true }
-sphinxcontrib-spelling = { version = "~= 7.3.3", optional = true }
-sphinx-autobuild = { version = "^2021.3.14", optional = true }
-tornado = { version = "^6.3.3", optional = true, python = ">=3.8,<3.13" }
-sphinx-inline-tabs = { version = "^2023.4.21", optional = true, python = ">=3.8,<3.13" }
-sphinxcontrib-mermaid = { version = "^0.9.2", optional = true, python = ">=3.7,<3.13" }
-myst-parser = { version = "^3.0.0", optional = true, markers = "python_version >= '3.8'", python = ">=3.10,<3.13" }
-# PREV
-# markdown-it-py = { version = ">=2.2.0, <3", optional = true, python= ">=3.8,<3.13" }
-# markdown-it-py = { version = ">=3.0,<4.0", optional = true, python = ">=3.8,<3.13" }
-# markdown-it-py = { version = ">=1,<4.0", optional = true, python = ">=3.8,<3.13" }
-# markdown-it-py = { version = ">=2.2.0", optional = true, python = ">=3.8,<3.13" }
-# NEW
-markdown-it-py = { version = "=3", optional = true, python = ">=3.8,<3.13" }
+[project.optional-dependencies]
+test = [
+    "pytest<8.0.0,>=7.2.0; python_version < \"3.13\" and python_version >= \"3.7\"",
+    "pytest-object-getter<2.0.0,>=1.0.1",
+    "pytest-click~=1.1.0",
+    "pytest-cov>=2.12",
+    "pytest-explicit~=1.0.1",
+    "pytest-xdist>=1.34",
+    "pytest-run-subprocess==0.9.0",
+    "pytest-requests-futures==0.9.0",
+    "build>=1.2.2.post1",
+]
+docs = [
+    "sphinx~=6.0; python_version < \"3.13\" and python_version >= \"3.8\"",
+    "sphinx-autodoc-typehints>=1.10",
+    "sphinx-rtd-theme==0.5.0",
+    "sphinxcontrib-spelling~=7.3.3",
+    "sphinx-inline-tabs<2024.0.0,>=2023.4.21; python_version < \"3.13\" and python_version >= \"3.8\"",
+    "sphinxcontrib-mermaid<1.0.0,>=0.9.2; python_version < \"3.13\" and python_version >= \"3.7\"",
+    "myst-parser<4.0.0,>=3.0.0; python_version >= \"3.10\" and python_version < \"3.13\"",
+    "markdown-it-py==3.0.0; python_version < \"3.13\" and python_version >= \"3.8\"",
+]
+docslive = [
+    "myst-parser>=3.0.1,<5.0.0",
+    "sphinx-autobuild<2022.0.0,>=2021.3.14",
+    "sphinx-inline-tabs==2023.4.21",
+    "sphinxcontrib-mermaid==0.9.2",
+    "sphinxcontrib-spelling >=7.3.3 , <8.0.0",
+    "tornado<7.0.0,>=6.3.3; python_version < \"3.13\" and python_version >= \"3.8\"",
+]
+typing = [
+    "types-requests~=2.27.26",
+    "types-pyyaml<7.0.0.0,>=6.0.12.5",
+    "mypy>=1.0.0",
+]
 
-rich = { version = "^13.0.0", python = ">=3.7,<3.13" }
+[project.scripts]
+generate-python = "cookiecutter_python.cli:main"
 
-# Type Checking: packages required for the type check (ie mypy) to pass
-mypy = { version = "== 0.961", optional = true }
-types-requests = { version = "~= 2.27.26", optional = true }
-types-pyyaml = { version = "^6.0.12.5", optional = true }
-jinja2-time = "^0.2.0"
-
-# PEP 508
-# requests [security,tests] >= 2.8.1, == 2.8.* ; python_version < "2.7"
-packaging = ">=22,<23"
+# [project.urls]
 
 
+
+
+#### PIP INSTALL EXTRAS - Integration ####
+# enables pip install -e 'cookiecutter-python[test]'
 [tool.poetry.extras]
 test = [
     "pytest",
-    "pytest-click",
-    "pytest-cov",
-    "pytest-explicit",
-    "pytest-xdist",
-    "pytest-object-getter",
     "pytest-run-subprocess",
-    "pytest-requests-futures",
-]
-docs = [
-    "sphinx",
-    "sphinx-autodoc-typehints",
-    "sphinx-rtd-theme",
-    "sphinxcontrib-spelling",
-    "sphinx-inline-tabs",
-    "sphinxcontrib-mermaid",
-    "myst-parser",
-    "markdown-it-py",
-]
-docslive = [
-    "sphinx",
-    "sphinx-autodoc-typehints",
-    "sphinx-rtd-theme",
-    "sphinxcontrib-spelling",
-    "sphinx-autobuild",
-    "tornado",
-    "sphinx-inline-tabs",
-    "sphinxcontrib-mermaid",
-    "myst-parser",
-    "markdown-it-py",
-]
-typing = [
-    "mypy",
-    "types-requests",
-    "pytest",
-    "pytest-click",
-    "types-pyyaml",
 ]
 
 
-# PyPi url links, that appear in 'Project Links' section
-[tool.poetry.urls]
-"Bug Tracker" = "https://github.com/boromir674/cookiecutter-python-package/issues"
-"CI: Github Actions" = "https://github.com/boromir674/cookiecutter-python-package/actions"
-"Documentation" = "https://python-package-generator.readthedocs.io/"
-"Source Code" = "https://github.com/boromir674/cookiecutter-python-package"
-# TODO Improve: add changelog in Docs and use that link below
-# https://cookiecutter-python-package.readthedocs.io/en/stable/changelog.html
-"Changelog" = "https://github.com/boromir674/cookiecutter-python-package/blob/master/CHANGELOG.rst"
-"Code of Conduct" = "https://github.com/boromir674/cookiecutter-python-package/blob/master/CONTRIBUTING.rst"
-# Mailing lists =
+#### TOOLS - Non UV / POETRY ####
 
-
-
-# TOOLS
-
-## Pytest & Plugins
+### Pytest & Plugins ###
 
 [tool.pytest.ini_options]
 minversion = "6.2"
 # hard-inject args, when invoking `pytest` CLI
 addopts = "--strict-markers --ignore=tests/data"
-# for explict --run-integration -> pip install pytest-explicit
+testpaths = [
+    "tests",
+]
 markers = [
     "slow: Marks a slow test",
     "integration: Tests applicable to a newly Generated Project, running with tox",
     "network_bound: Require internet connection",
+    "requires_uv: Tests that need to execute the uv binary",
 ]
-testpaths = [
-    "tests",
-]
+# for explict --run-integration -> pip install pytest-explicit
 explicit-only = [
     "integration",
     "network_bound",
     "slow",
-]
-
-
-## Black formatting/linting
-
-[tool.black]
-line-length = 95
-include = '\.pyi?$'
-extend-exclude = '''
-# A regex preceeded with ^/ will apply only to files and directories
-# in the root of the project.
-# ^/foo.py  # exclude a file named foo.py in the root of the project (in addition to the defaults)
-tests/smoke_test.py|
-hooks/post_gen_project.py
-'''
-
-
-[tool.isort]
-profile = 'black'
-
-
-[tool.software-release]
-version_variable = "src/cookiecutter_python/__init__.py:__version__"
-
-
-# BANDIT
-
-[tool.bandit]
-exclude_dirs = ["tests/data", "path/to/file"]
-tests = []
-skips = [
-    "B101",
+    "requires_uv",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ typing = [
     "types-requests~=2.27.26",
     "types-pyyaml<7.0.0.0,>=6.0.12.5",
     "mypy>=1.0.0",
+    "pytest>=7.4.4",
 ]
 
 [project.scripts]

--- a/scripts/update-snapshot-interactive.sh
+++ b/scripts/update-snapshot-interactive.sh
@@ -4,7 +4,7 @@
 # Regression Tests
 
 set -e
-export TOXPYTHON=python3.10
+
 # From 'edit' mode installation:
 echo
 tox -e dev -vv --notest

--- a/scripts/update-snapshot.sh
+++ b/scripts/update-snapshot.sh
@@ -3,7 +3,7 @@
 # Update the Snashot Biskotaki (ci) Test Data maintained for Regression Tests
 
 set -e
-export TOXPYTHON=python3.10
+
 # From 'edit' mode installation:
 echo
 tox -e dev -vv --notest

--- a/scripts/visualize-dockerfile.py
+++ b/scripts/visualize-dockerfile.py
@@ -123,7 +123,10 @@ def parse_cli_args() -> t.Tuple[Path, t.Optional[str]]:
     parser = argparse.ArgumentParser(description='Process Dockerfile paths.')
 
     parser.add_argument(
-        'dockerfile_path', nargs='?', default='Dockerfile', help='Path to the Dockerfile'
+        'dockerfile_path',
+        nargs='?',
+        default='Dockerfile',
+        help='Path to the Dockerfile',
     )
     parser.add_argument(
         '-o', '--output', help='Output path. If not specified, print to stdout.'

--- a/src/cookiecutter_python/backend/error_handling/handler_builder.py
+++ b/src/cookiecutter_python/backend/error_handling/handler_builder.py
@@ -1,8 +1,12 @@
 import click
 from software_patterns import SubclassRegistry
+import typing as t
 
 
-class HandlerBuilder(metaclass=SubclassRegistry):
+class HandlerBuilderRegistry(SubclassRegistry[t.Callable]):
+    pass
+
+class HandlerBuilder(metaclass=HandlerBuilderRegistry):
     pass
 
 

--- a/src/cookiecutter_python/backend/error_handling/handler_builder.py
+++ b/src/cookiecutter_python/backend/error_handling/handler_builder.py
@@ -1,6 +1,7 @@
+import typing as t
+
 import click
 from software_patterns import SubclassRegistry
-import typing as t
 
 
 class HandlerBuilderRegistry(SubclassRegistry[t.Callable]):

--- a/src/cookiecutter_python/backend/error_handling/handler_builder.py
+++ b/src/cookiecutter_python/backend/error_handling/handler_builder.py
@@ -7,6 +7,7 @@ from software_patterns import SubclassRegistry
 class HandlerBuilderRegistry(SubclassRegistry[t.Callable]):
     pass
 
+
 class HandlerBuilder(metaclass=HandlerBuilderRegistry):
     pass
 

--- a/src/cookiecutter_python/backend/gen_docs_common.py
+++ b/src/cookiecutter_python/backend/gen_docs_common.py
@@ -4,7 +4,9 @@ import typing as t
 from pathlib import Path
 
 # Runtime folder path of {{ cookiecutter.project_slug }}
-PROJ_TEMPLATE_DIR: Path = Path(__file__).parent.parent / '{{ cookiecutter.project_slug }}'
+PROJ_TEMPLATE_DIR: Path = (
+    Path(__file__).parent.parent / '{{ cookiecutter.project_slug }}'
+)
 
 # Reminder: the Template Design (TD) is defined by the:
 #   - Template Variables; ie cookiecutter.json

--- a/src/cookiecutter_python/backend/helpers.py
+++ b/src/cookiecutter_python/backend/helpers.py
@@ -83,7 +83,9 @@ def parse_context(config_file: str):
                 "full_name": context_defaults['full_name'],
                 "author_email": context_defaults['author_email'],
                 "github_username": context_defaults['github_username'],
-                "project_short_description": context_defaults['project_short_description'],
+                "project_short_description": context_defaults[
+                    'project_short_description'
+                ],
                 # "release_date": context_defaults['release_date'],
                 # "year": context_defaults['year'],
                 "version": context_defaults['version'],

--- a/src/cookiecutter_python/backend/hosting_services/handle_hosting_service_check.py
+++ b/src/cookiecutter_python/backend/hosting_services/handle_hosting_service_check.py
@@ -11,7 +11,9 @@ HostingServiceChecker = t.Callable[[str], bool]
 class CheckHostingServiceHandler:
     check_hosting_service: HostingServiceChecker
     service_name: str = attr.ib(
-        default=attr.Factory(lambda self: str(self.check_hosting_service), takes_self=True)
+        default=attr.Factory(
+            lambda self: str(self.check_hosting_service), takes_self=True
+        )
     )
     package_name: str = attr.ib(init=False, default=None)
 

--- a/src/cookiecutter_python/backend/hosting_services/handler.py
+++ b/src/cookiecutter_python/backend/hosting_services/handler.py
@@ -17,7 +17,9 @@ class Handlers:
 
     @staticmethod
     def from_checkers(checkers):
-        return Handlers({str(x): CheckHostingServiceResultHandler(str(x)) for x in checkers})
+        return Handlers(
+            {str(x): CheckHostingServiceResultHandler(str(x)) for x in checkers}
+        )
 
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)

--- a/src/cookiecutter_python/backend/load_config.py
+++ b/src/cookiecutter_python/backend/load_config.py
@@ -22,7 +22,9 @@ def load_yaml(config_file) -> t.MutableMapping:
     return yaml_dict
 
 
-def get_interpreters_from_yaml(config_file: str) -> t.Optional[t.Mapping[str, t.Sequence[str]]]:
+def get_interpreters_from_yaml(
+    config_file: str,
+) -> t.Optional[t.Mapping[str, t.Sequence[str]]]:
     """Parse the 'interpreters' variable out of the user's config yaml file.
 
     Args:

--- a/src/cookiecutter_python/backend/load_config.py
+++ b/src/cookiecutter_python/backend/load_config.py
@@ -6,8 +6,6 @@ from json import JSONDecodeError
 
 import yaml
 
-GivenInterpreters = t.Mapping[str, t.Sequence[str]]
-
 logger = logging.getLogger(__name__)
 
 
@@ -24,7 +22,7 @@ def load_yaml(config_file) -> t.MutableMapping:
     return yaml_dict
 
 
-def get_interpreters_from_yaml(config_file: str) -> t.Optional[GivenInterpreters]:
+def get_interpreters_from_yaml(config_file: str) -> t.Optional[t.Mapping[str, t.Sequence[str]]]:
     """Parse the 'interpreters' variable out of the user's config yaml file.
 
     Args:
@@ -35,7 +33,7 @@ def get_interpreters_from_yaml(config_file: str) -> t.Optional[GivenInterpreters
         UserYamlDesignError: if yaml does not contain the 'default_context' key
 
     Returns:
-        GivenInterpreters: dictionary with intepreters as a sequence of strings,
+        t.Mapping[str, t.Sequence[str]]: dictionary with intepreters as a sequence of strings,
             mapped to the 'supported-interpreters' key
     """
     data = load_yaml(config_file)

--- a/src/cookiecutter_python/backend/pre_main.py
+++ b/src/cookiecutter_python/backend/pre_main.py
@@ -1,4 +1,3 @@
-
 from .helpers import parse_context
 from .hosting_services import Engine
 

--- a/src/cookiecutter_python/backend/pre_main.py
+++ b/src/cookiecutter_python/backend/pre_main.py
@@ -59,7 +59,7 @@ def pre_main(request):
             # just update interpreters cookiecutter extra_context
             from .load_config import get_interpreters_from_yaml
 
-            interpreters: t.Mapping[str, t.Sequence[str]] = get_interpreters_from_yaml(
+            interpreters = get_interpreters_from_yaml(
                 request.config_file
             )
             if interpreters:

--- a/src/cookiecutter_python/backend/pre_main.py
+++ b/src/cookiecutter_python/backend/pre_main.py
@@ -1,4 +1,3 @@
-import typing as t
 
 from .helpers import parse_context
 from .hosting_services import Engine

--- a/src/cookiecutter_python/backend/pre_main.py
+++ b/src/cookiecutter_python/backend/pre_main.py
@@ -59,9 +59,7 @@ def pre_main(request):
             # just update interpreters cookiecutter extra_context
             from .load_config import get_interpreters_from_yaml
 
-            interpreters = get_interpreters_from_yaml(
-                request.config_file
-            )
+            interpreters = get_interpreters_from_yaml(request.config_file)
             if interpreters:
                 _context['interpreters'] = interpreters
 

--- a/src/cookiecutter_python/backend/request.py
+++ b/src/cookiecutter_python/backend/request.py
@@ -1,5 +1,6 @@
-from typing import Any, Iterable, List, Union
 import typing as t
+from typing import Any, Iterable, List, Union
+
 import attr
 
 from .check_server_result import CheckWebServerResult

--- a/src/cookiecutter_python/backend/request.py
+++ b/src/cookiecutter_python/backend/request.py
@@ -1,5 +1,5 @@
 from typing import Any, Iterable, List, Union
-
+import typing as t
 import attr
 
 from .check_server_result import CheckWebServerResult
@@ -7,11 +7,11 @@ from .check_server_result import CheckWebServerResult
 
 @attr.s(kw_only=True, auto_attribs=True, slots=True)
 class Request:
-    config_file: str
+    config_file: t.Union[str, None]
     default_config: bool
     web_servers: List[str]
     no_input: bool
-    extra_context: dict
+    extra_context: t.Union[t.Dict, None]
     check: Any = attr.ib(default=None)
     check_results: Union[None, Iterable[CheckWebServerResult]] = attr.ib(default=None)
     offline: bool = False

--- a/src/cookiecutter_python/backend/sanitization/input_sanitization.py
+++ b/src/cookiecutter_python/backend/sanitization/input_sanitization.py
@@ -22,7 +22,9 @@ class Sanitize:
     def __iter_exceptions(self) -> t.Iterator[t.Tuple[str, ExceptionValue]]:
         for key, exceptions_list in self.exceptions_map.items():
             exception: ExceptionValue = (
-                exceptions_list[0] if len(exceptions_list) == 1 else tuple(exceptions_list)
+                exceptions_list[0]
+                if len(exceptions_list) == 1
+                else tuple(exceptions_list)
             )
             yield key, exception
 

--- a/src/cookiecutter_python/backend/sanitization/string_sanitizers/sanitize_reg_input.py
+++ b/src/cookiecutter_python/backend/sanitization/string_sanitizers/sanitize_reg_input.py
@@ -1,8 +1,8 @@
 import json
 import logging
 import typing as t
-from typing import Pattern, Tuple
 from abc import abstractmethod
+from typing import Pattern, Tuple
 
 from ..input_sanitization import Sanitize
 from .base_sanitizer import BaseSanitizer

--- a/src/cookiecutter_python/backend/sanitization/string_sanitizers/sanitize_reg_input.py
+++ b/src/cookiecutter_python/backend/sanitization/string_sanitizers/sanitize_reg_input.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import typing as t
-from abc import abstractmethod
 from typing import Pattern, Tuple
 
 from ..input_sanitization import Sanitize

--- a/src/cookiecutter_python/backend/sanitization/string_sanitizers/sanitize_reg_input.py
+++ b/src/cookiecutter_python/backend/sanitization/string_sanitizers/sanitize_reg_input.py
@@ -35,7 +35,9 @@ class RegExSanitizer:
 
         def _log_message(error, input_data):
             raw_log_args: Tuple = type(self).log_message(error, input_data)
-            return tuple([raw_log_args[0]] + [self._string(x) for x in raw_log_args[1:]])
+            return tuple(
+                [raw_log_args[0]] + [self._string(x) for x in raw_log_args[1:]]
+            )
 
         type(self).sanitizer = BaseSanitizer(
             self._verify,

--- a/src/cookiecutter_python/backend/user_config_proxy.py
+++ b/src/cookiecutter_python/backend/user_config_proxy.py
@@ -26,7 +26,9 @@ class GetUserConfigSubject(ProxySubject[ReturnValueType]):
 class GetUserConfigProxy(BaseProxy[ReturnValueType]):
     def request(self, *args, **kwargs):
         logger.info(
-            *BaseProxy.log_info_args('Get User Config Proxy Request: %s', *args, **kwargs)
+            *BaseProxy.log_info_args(
+                'Get User Config Proxy Request: %s', *args, **kwargs
+            )
         )
         return super().request(*args, **kwargs)
 

--- a/src/cookiecutter_python/handle/dialogs/lib/project_name.py
+++ b/src/cookiecutter_python/handle/dialogs/lib/project_name.py
@@ -37,7 +37,9 @@ class ProjectNameDialog:
                     'type': 'input',
                     'name': 'pkg_name',
                     'message': 'Enter the Package Name (ie lowercase text, no spaces):',
-                    'default': lambda answers: answers['project_slug'].replace('-', '_'),
+                    'default': lambda answers: answers['project_slug'].replace(
+                        '-', '_'
+                    ),
                 },
                 {
                     'type': 'input',

--- a/src/cookiecutter_python/hooks/post_gen_project.py
+++ b/src/cookiecutter_python/hooks/post_gen_project.py
@@ -94,7 +94,7 @@ delete_files = {
 }
 
 ### Define specialized files present per 'CI/CD option' ###
-CICD_DELETE = {
+CICD_DELETE: t.Dict[str, t.List[t.Tuple[str, ...]]] = {
     'stable': [
         ('.github', 'workflows', 'cicd.yml'),
         ('.github', 'workflows', 'codecov-upload.yml'),

--- a/src/cookiecutter_python/hooks/pre_gen_project.py
+++ b/src/cookiecutter_python/hooks/pre_gen_project.py
@@ -14,8 +14,8 @@ def get_request():
     # Templated Variables should be centralized here for easier inspection
     # Also, this makes static code analyzers to avoid issues with syntax errors
     # due to the templated (dynamically injected) code in this file
-    cookiecutter = OrderedDict()
-    cookiecutter: OrderedDict = {{cookiecutter}}
+    cookiecutter: OrderedDict = OrderedDict()
+    cookiecutter: OrderedDict = {{cookiecutter}}  # type:ignore[no-redef]
 
     logger.info("Cookiecutter Data: %s", json.dumps(cookiecutter, sort_keys=True, indent=4))
 

--- a/src/cookiecutter_python/{{ cookiecutter.project_slug }}/scripts/visualize-ga-workflow.py
+++ b/src/cookiecutter_python/{{ cookiecutter.project_slug }}/scripts/visualize-ga-workflow.py
@@ -74,7 +74,9 @@ def generate_mermaid(job_dependencies: t.Dict[str, t.List[str]]) -> str:
     mermaid_code = 'graph LR;\n'
     for job_name, needs in job_dependencies.items():
         if needs:
-            mermaid_code += '\n'.join([f'  {prev_job} --> {job_name}' for prev_job in needs]) + '\n'
+            mermaid_code += (
+                '\n'.join([f'  {prev_job} --> {job_name}' for prev_job in needs]) + '\n'
+            )
         else:
             mermaid_code += f'  {job_name}\n'
 

--- a/src/stubs/git/exc.pyi
+++ b/src/stubs/git/exc.pyi
@@ -1,0 +1,1 @@
+class InvalidGitRepositoryError(Exception): pass

--- a/tests/biskotaki_ci/conftest.py
+++ b/tests/biskotaki_ci/conftest.py
@@ -29,6 +29,7 @@ def biskotaki_ci_project(
     #### if running OUTSIDE of local checkout ####
 
     TEST_TIME_BISKOTAKI_CONFIG = None
+    biskotaki_yaml: Path
 
     if not (test_root.parent / '.github' / 'biskotaki.yaml').exists():
         import tempfile
@@ -64,7 +65,7 @@ default_context:
     else:
         #### else RUNNING_FROM_LOCAL_CHECKOUT ####
         
-        biskotaki_yaml: Path = test_root.parent / '.github' / 'biskotaki.yaml'
+        biskotaki_yaml = test_root.parent / '.github' / 'biskotaki.yaml'
         assert biskotaki_yaml.exists()
         assert biskotaki_yaml.is_file()
         assert biskotaki_yaml.name == 'biskotaki.yaml'

--- a/tests/biskotaki_ci/conftest.py
+++ b/tests/biskotaki_ci/conftest.py
@@ -36,7 +36,8 @@ def biskotaki_ci_project(
 
         # Create a temporary file to use as a test config and PRESERVE it on close!
         with tempfile.NamedTemporaryFile(mode='w+b', delete=False) as fp:
-            fp.write(b"""
+            fp.write(
+                b"""
 default_context:
     project_name: Biskotaki
     project_type: module
@@ -59,13 +60,14 @@ default_context:
     rtd_python_version: "3.10"
     cicd: 'experimental'
 
-""")
+"""
+            )
             fp.close()
             TEST_TIME_BISKOTAKI_CONFIG = Path(fp.name)
         biskotaki_yaml = TEST_TIME_BISKOTAKI_CONFIG
     else:
         #### else RUNNING_FROM_LOCAL_CHECKOUT ####
-        
+
         biskotaki_yaml = test_root.parent / '.github' / 'biskotaki.yaml'
         assert biskotaki_yaml.exists()
         assert biskotaki_yaml.is_file()

--- a/tests/biskotaki_ci/conftest.py
+++ b/tests/biskotaki_ci/conftest.py
@@ -33,6 +33,7 @@ def biskotaki_ci_project(
 
     if not (test_root.parent / '.github' / 'biskotaki.yaml').exists():
         import tempfile
+
         # Create a temporary file to use as a test config and PRESERVE it on close!
         with tempfile.NamedTemporaryFile(mode='w+b', delete=False) as fp:
             fp.write(b"""

--- a/tests/biskotaki_ci/conftest.py
+++ b/tests/biskotaki_ci/conftest.py
@@ -26,10 +26,50 @@ def biskotaki_ci_project(
     assert test_root.name == 'tests'
     assert test_root.is_absolute()
 
-    biskotaki_yaml: Path = test_root.parent / '.github' / 'biskotaki.yaml'
-    assert biskotaki_yaml.exists()
-    assert biskotaki_yaml.is_file()
-    assert biskotaki_yaml.name == 'biskotaki.yaml'
+    #### if running OUTSIDE of local checkout ####
+
+    TEST_TIME_BISKOTAKI_CONFIG = None
+
+    if not (test_root.parent / '.github' / 'biskotaki.yaml').exists():
+        import tempfile
+        # Create a temporary file to use as a test config and PRESERVE it on close!
+        with tempfile.NamedTemporaryFile(mode='w+b', delete=False) as fp:
+            fp.write(b"""
+default_context:
+    project_name: Biskotaki
+    project_type: module
+    project_slug: biskotaki
+    pkg_name: biskotaki
+    repo_name: biskotaki
+    readthedocs_project_slug: biskotaki
+    docker_image: biskotaki
+    full_name: Konstantinos Lampridis
+    author: Konstantinos Lampridis
+    email: k.lampridis@hotmail.com
+    author_email: k.lampridis@hotmail.com
+    github_username: boromir674
+    project_short_description: Project generated using https://github.com/boromir674/cookiecutter-python-package
+    initialize_git_repo: 'no'
+    interpreters: {"supported-interpreters": ["3.7", "3.8", "3.9", "3.10", "3.11"]}
+    ## Documentation Config ##
+    docs_builder: "sphinx"
+    ## READ THE DOCS CI Config ##
+    rtd_python_version: "3.10"
+    cicd: 'experimental'
+
+""")
+            fp.close()
+            TEST_TIME_BISKOTAKI_CONFIG = Path(fp.name)
+        biskotaki_yaml = TEST_TIME_BISKOTAKI_CONFIG
+    else:
+        #### else RUNNING_FROM_LOCAL_CHECKOUT ####
+        
+        biskotaki_yaml: Path = test_root.parent / '.github' / 'biskotaki.yaml'
+        assert biskotaki_yaml.exists()
+        assert biskotaki_yaml.is_file()
+        assert biskotaki_yaml.name == 'biskotaki.yaml'
+
+    ### END ###
 
     # Mock Network Code, in case http (Future) requests are made
     mock_check.config = user_config[biskotaki_yaml]

--- a/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py
+++ b/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py
@@ -77,6 +77,6 @@ def test_running_ruff_passes(snapshot_name, test_root):
         shutil.rmtree(snapshot_dir / '.tox' / 'ruff')
 
     # SANITY verify .tox/ruff exists, when using tox 3.x
-    assert res.returncode == 0, f"Failed to run `tox -e ruff` for {snapshot_name}\nSTDOUT:\n{res.stdout}\nSTDERR:\n{res.stderr}"
+    assert res.returncode == 0, f"Failed to run `tox -e ruff` for {snapshot_name}\nSTDOUT:\n{res.stdout.decode(encoding='utf-8')}\nSTDERR:\n{res.stderr.decode(encoding='utf-8')}"
 
     # VERIFIED that Generator emits python code that pass Ruff out of the box !!

--- a/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py
+++ b/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py
@@ -77,6 +77,8 @@ def test_running_ruff_passes(snapshot_name, test_root):
         shutil.rmtree(snapshot_dir / '.tox' / 'ruff')
 
     # SANITY verify .tox/ruff exists, when using tox 3.x
-    assert res.returncode == 0, f"Failed to run `tox -e ruff` for {snapshot_name}\nSTDOUT:\n{res.stdout.decode(encoding='utf-8')}\nSTDERR:\n{res.stderr.decode(encoding='utf-8')}"
+    assert (
+        res.returncode == 0
+    ), f"Failed to run `tox -e ruff` for {snapshot_name}\nSTDOUT:\n{res.stdout.decode(encoding='utf-8')}\nSTDERR:\n{res.stderr.decode(encoding='utf-8')}"
 
     # VERIFIED that Generator emits python code that pass Ruff out of the box !!

--- a/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py
+++ b/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py
@@ -70,13 +70,13 @@ def test_running_ruff_passes(snapshot_name, test_root):
         check=False,  # prevent raising exception, so we can do clean up
     )
 
+    if (snapshot_dir / '.tox' / 'ruff').exists():
+        # Remove .tox/ruff folder, created by tox 3.x
+        import shutil
+
+        shutil.rmtree(snapshot_dir / '.tox' / 'ruff')
+
     # SANITY verify .tox/ruff exists, when using tox 3.x
-    assert (snapshot_dir / '.tox' / 'ruff').exists()
+    assert res.returncode == 0, f"Failed to run `tox -e ruff` for {snapshot_name}\nSTDOUT:\n{res.stdout}\nSTDERR:\n{res.stderr}"
 
-    # Remove .tox/ruff folder, created by tox 3.x
-    import shutil
-
-    shutil.rmtree(snapshot_dir / '.tox' / 'ruff')
-
-    # Check that Code passes Lint out of the box
-    assert res.returncode == 0
+    # VERIFIED that Generator emits python code that pass Ruff out of the box !!

--- a/tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py
+++ b/tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py
@@ -98,6 +98,7 @@ def test_snapshot_matches_runtime(snapshot, biskotaki_ci_project, test_root):
                 if '.vscode' not in x.parts
                 and 'settings.json' not in x.parts
                 and '.tox' not in x.parts
+                and 'dist' not in x.parts
                 and '.mypy_cache' not in x.parts
                 and x.parts
                 not in {
@@ -153,7 +154,9 @@ def test_snapshot_matches_runtime(snapshot, biskotaki_ci_project, test_root):
     )
 
     if RUNNING_ON_CI:  # quickly do sanity check
-        assert all([line_pair[0] == line_pair[1] for line_pair in line_pairs_generator]), (
+        assert all(
+            [line_pair[0] == line_pair[1] for line_pair in line_pairs_generator]
+        ), (
             f"File: CHANGELOG.rst has different content at Runtime vs Snapshot\n"
             "-------------------\n"
             f"Runtime: {runtime_changelog}\n"
@@ -194,7 +197,9 @@ def test_snapshot_matches_runtime(snapshot, biskotaki_ci_project, test_root):
         ]
     )
     if RUNNING_ON_CI:  # quickly do sanity check
-        assert all([line_pair[0] == line_pair[1] for line_pair in line_pairs_generator]), (
+        assert all(
+            [line_pair[0] == line_pair[1] for line_pair in line_pairs_generator]
+        ), (
             f"File: docs/conf.py has different content at Runtime vs Snapshot\n"
             "-------------------\n"
             f"Runtime: {runtime_conf}\n"

--- a/tests/biskotaki_ci/snapshot/test_valid_ci_config.py
+++ b/tests/biskotaki_ci/snapshot/test_valid_ci_config.py
@@ -39,15 +39,15 @@ def test_snapshot_ci_config_files_are_valid_yaml(snapshot_name, test_root):
     # Load CI Config
     import re
 
-    def sanitize_load(s):
+    def sanitize_load(text: str):
         for w in "on".split():
             reg = re.compile(r'^(on):', re.MULTILINE)
-            s: str = reg.sub(r'\1<TEST>:', s)
+            text = reg.sub(r'\1<TEST>:', text)
         # >> Issue: [B506:yaml_load] Use of unsafe yaml load. Allows instantiation of arbitrary objects. Consider yaml.safe_load().
         # Severity: Medium   Confidence: High
         # CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
         # More Info: https://bandit.readthedocs.io/en/1.7.7/plugins/b506_yaml_load.html
-        return yaml.safe_load(s)
+        return yaml.safe_load(text)
 
     ci_config = sanitize_load(ci_config_file.read_text())
 
@@ -67,10 +67,10 @@ def test_snapshot_ci_config_files_are_valid_yaml(snapshot_name, test_root):
     ### Validate .github/workflows/policy_lint.yml ###
 
     # Load CI Config File
-    ci_config_file: Path = snapshot_dir / '.github' / 'workflows' / 'policy_lint.yml'
+    ci_config_file = snapshot_dir / '.github' / 'workflows' / 'policy_lint.yml'
     assert ci_config_file.exists()
     assert ci_config_file.is_file()
 
     # Load CI Config
-    ci_config: dict = yaml.safe_load(ci_config_file.read_text())
+    ci_config = yaml.safe_load(ci_config_file.read_text())
     assert ci_config

--- a/tests/biskotaki_ci/test_logging.py
+++ b/tests/biskotaki_ci/test_logging.py
@@ -1,5 +1,6 @@
-import pytest
 from pathlib import Path
+
+import pytest
 
 
 @pytest.fixture

--- a/tests/biskotaki_ci/test_logging.py
+++ b/tests/biskotaki_ci/test_logging.py
@@ -100,7 +100,7 @@ def test_log_file_not_present_in_newly_generated_project(
     # exception misbehaviour fixed on Windows?
     import os
 
-    has_developer_mitigated_windows_glitch: bool = (
+    has_developer_mitigated_windows_glitch = (
         os.environ.get("BUG_LOG_DEL_WIN") != "permission_error"
     )
 

--- a/tests/biskotaki_ci/test_logging.py
+++ b/tests/biskotaki_ci/test_logging.py
@@ -10,7 +10,7 @@ def biskotaki_ci_like_gen_proj(tmp_path):
 
     # GIVEN any existing valid config file to use in generation
     config_file: Path = tmp_path / 'any_valid_config_file.yml'
-    
+
     config_file.write_text(
         """
 default_context:

--- a/tests/biskotaki_ci/test_logging.py
+++ b/tests/biskotaki_ci/test_logging.py
@@ -1,5 +1,45 @@
+import pytest
+from pathlib import Path
+
+
+@pytest.fixture
+def biskotaki_ci_like_gen_proj(tmp_path):
+
+    from cookiecutter_python.backend.main import generate
+
+    # GIVEN any existing valid config file to use in generation
+    config_file: Path = tmp_path / 'any_valid_config_file.yml'
+    
+    config_file.write_text(
+        """
+default_context:
+    project_name: Anything Project
+    full_name: GG ELA
+    author: GG ELA
+    email: GG.ELA@email.com
+    github_username: ggela1234567
+    project_short_description: Project generated using https://github.com/boromir674/cookiecutter-python-package
+    initialize_git_repo: 'no'
+    interpreters: {"supported-interpreters": ["3.8", "3.9", "3.10", "3.11", "3.12"]}
+    docs_builder: "mkdocs"
+    rtd_python_version: "3.11"
+    cicd: 'stable'
+"""
+    )
+
+    ######## GENERATE Biskotaki from CI Config Yaml ########
+    project_dir: str = generate(
+        no_input=True,
+        offline=True,
+        output_dir=tmp_path / 'gen',  # Path or string to a folder path
+        config_file=str(config_file),  # better be a string
+        default_config=False,
+    )
+    return Path(project_dir)
+
+
 def test_log_file_not_present_in_newly_generated_project(
-    biskotaki_ci_project,
+    biskotaki_ci_like_gen_proj,
 ):
     """Test that the log file is not present inside the `cookiecutter.project_slug` folder"""
     import sys
@@ -9,7 +49,7 @@ def test_log_file_not_present_in_newly_generated_project(
     # exception misbehaviour fixed on Windows?
     import os
 
-    has_developer_fixed_windows_mishap: bool = (
+    has_developer_mitigated_windows_glitch: bool = (
         os.environ.get("BUG_LOG_DEL_WIN") != "permission_error"
     )
 
@@ -26,7 +66,7 @@ def test_log_file_not_present_in_newly_generated_project(
     # logs_folder: Path = LOG_FILE.parent
 
     # WHEN we Generate a new Project, and get the Root Folder (ie repo root dir)
-    runtime_generated_project: Path = biskotaki_ci_project
+    runtime_generated_project: Path = biskotaki_ci_like_gen_proj
 
     # THEN we expect Logs Captured from Runtime Code execution to be written in
     # a file present inside the shell's PWD
@@ -60,7 +100,7 @@ def test_log_file_not_present_in_newly_generated_project(
     # exception misbehaviour fixed on Windows?
     import os
 
-    has_developer_fixed_windows_mishap: bool = (
+    has_developer_mitigated_windows_glitch: bool = (
         os.environ.get("BUG_LOG_DEL_WIN") != "permission_error"
     )
 
@@ -70,11 +110,11 @@ def test_log_file_not_present_in_newly_generated_project(
             running_on_windows
             and (
                 (
-                    has_developer_fixed_windows_mishap
+                    has_developer_mitigated_windows_glitch
                     and not UNINTENTIONALLY_PLACED_LOG_FILE.exists()
                 )
                 or (
-                    not has_developer_fixed_windows_mishap
+                    not has_developer_mitigated_windows_glitch
                     and UNINTENTIONALLY_PLACED_LOG_FILE.exists()
                 )
             )

--- a/tests/biskotaki_ci/test_regression_biskotaki.py
+++ b/tests/biskotaki_ci/test_regression_biskotaki.py
@@ -30,7 +30,9 @@ def test_gen_ci_biskotaki_has_expected_files(
     ## AND a file, that we expect to be generated
     # supplied by the 'biskotaki_file_expected' fixture, passed in this test
     expected_file: str = biskotaki_file_expected
-    assert isinstance(expected_file, str), f"expected_file: {expected_file} is not a string"
+    assert isinstance(
+        expected_file, str
+    ), f"expected_file: {expected_file} is not a string"
     expected_file_path: Path = Path(expected_file)
     # sanity that path is relative, so that we can use it to check for existence
     assert (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,6 +304,7 @@ def request_factory(distro_loc) -> t.Type[EmulatedRequestFactory]:
 
     class HookRequestFacility(SubclassRegistry[EmulatedHookRequest]):
         pass
+
     class HookRequest(metaclass=HookRequestFacility):
         pass
 
@@ -562,6 +563,7 @@ class ConfigProtocol(Protocol):
     data: t.Mapping
     config_file: t.Union[str, None]
 
+
 class ConfigInterfaceProtocol(t.Protocol):
     def __getitem__(self, file_path_str: t.Union[str, None]) -> ConfigProtocol: ...
 
@@ -633,7 +635,9 @@ def user_config(distro_loc: Path) -> ConfigInterfaceProtocol:
                 }
 
                 data_file = Path(my_dir) / '..' / config_files.get(self.path, self.path)
-                assert data_file.exists(), f"{data_file} does not exist. Possilbly running test suite outside of source directory."
+                assert (
+                    data_file.exists()
+                ), f"{data_file} does not exist. Possilbly running test suite outside of source directory."
                 assert data_file.is_file()
 
                 self._config_file_arg = data_file

--- a/tests/data/snapshots/biskotaki-gold-standard/scripts/visualize-ga-workflow.py
+++ b/tests/data/snapshots/biskotaki-gold-standard/scripts/visualize-ga-workflow.py
@@ -74,7 +74,9 @@ def generate_mermaid(job_dependencies: t.Dict[str, t.List[str]]) -> str:
     mermaid_code = 'graph LR;\n'
     for job_name, needs in job_dependencies.items():
         if needs:
-            mermaid_code += '\n'.join([f'  {prev_job} --> {job_name}' for prev_job in needs]) + '\n'
+            mermaid_code += (
+                '\n'.join([f'  {prev_job} --> {job_name}' for prev_job in needs]) + '\n'
+            )
         else:
             mermaid_code += f'  {job_name}\n'
 

--- a/tests/data/snapshots/biskotaki-gold-standard/src/biskotakigold/cli.py
+++ b/tests/data/snapshots/biskotaki-gold-standard/src/biskotakigold/cli.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 import click
-
 from biskotakigold import __version__
 
 this_file_location = os.path.dirname(os.path.realpath(os.path.abspath(__file__)))

--- a/tests/data/snapshots/biskotaki-gold-standard/src/biskotakigold/cli.py
+++ b/tests/data/snapshots/biskotaki-gold-standard/src/biskotakigold/cli.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import click
+
 from biskotakigold import __version__
 
 this_file_location = os.path.dirname(os.path.realpath(os.path.abspath(__file__)))

--- a/tests/data/snapshots/biskotaki-interactive/scripts/visualize-ga-workflow.py
+++ b/tests/data/snapshots/biskotaki-interactive/scripts/visualize-ga-workflow.py
@@ -74,7 +74,9 @@ def generate_mermaid(job_dependencies: t.Dict[str, t.List[str]]) -> str:
     mermaid_code = 'graph LR;\n'
     for job_name, needs in job_dependencies.items():
         if needs:
-            mermaid_code += '\n'.join([f'  {prev_job} --> {job_name}' for prev_job in needs]) + '\n'
+            mermaid_code += (
+                '\n'.join([f'  {prev_job} --> {job_name}' for prev_job in needs]) + '\n'
+            )
         else:
             mermaid_code += f'  {job_name}\n'
 

--- a/tests/data/snapshots/biskotaki-no-input/scripts/visualize-ga-workflow.py
+++ b/tests/data/snapshots/biskotaki-no-input/scripts/visualize-ga-workflow.py
@@ -74,7 +74,9 @@ def generate_mermaid(job_dependencies: t.Dict[str, t.List[str]]) -> str:
     mermaid_code = 'graph LR;\n'
     for job_name, needs in job_dependencies.items():
         if needs:
-            mermaid_code += '\n'.join([f'  {prev_job} --> {job_name}' for prev_job in needs]) + '\n'
+            mermaid_code += (
+                '\n'.join([f'  {prev_job} --> {job_name}' for prev_job in needs]) + '\n'
+            )
         else:
             mermaid_code += f'  {job_name}\n'
 

--- a/tests/test_build_backend_sdist.py
+++ b/tests/test_build_backend_sdist.py
@@ -1,8 +1,9 @@
 """Test building our Source Distribution results in expected File System"""
 
 import typing as t
-import pytest
 from pathlib import Path
+
+import pytest
 
 
 @pytest.fixture(scope="session")
@@ -467,7 +468,7 @@ def sdist_built_at_runtime_with_uv(run_subprocess) -> Path:
 
     # result = run_subprocess('uv', 'python', 'pin', sys.executable, check=False)
     # assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}\n"
-    
+
     # invoke uv as build frontend to whatever [build-system] is in pyproject.toml
     COMMAND_LINE_ARGS: t.List[str] = [
         # 'uv', 'python', 'pin', sys.executable, '&&',

--- a/tests/test_build_backend_sdist.py
+++ b/tests/test_build_backend_sdist.py
@@ -468,7 +468,6 @@ def sdist_built_at_runtime_with_uv(run_subprocess) -> Path:
 
     # result = run_subprocess('uv', 'python', 'pin', sys.executable, check=False)
     # assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}\n"
-
     # invoke uv as build frontend to whatever [build-system] is in pyproject.toml
     COMMAND_LINE_ARGS: t.List[str] = [
         # 'uv', 'python', 'pin', sys.executable, '&&',

--- a/tests/test_build_backend_sdist.py
+++ b/tests/test_build_backend_sdist.py
@@ -71,6 +71,7 @@ def run_subprocess():
 
     return execute_command_in_subprocess
 
+
 # EXPECTATIONS as fixture
 @pytest.fixture(scope="session")
 def sdist_expected_correct_file_structure():
@@ -388,9 +389,9 @@ def verify_file_size_within_acceptable_limits():
         file: Path, size_acceptance_criteria: SizeAcceptanceCriteria
     ) -> t.Tuple[bool, t.Optional[str]]:
         expected_size = size_acceptance_criteria["expected_size"]
-        allowed_margin = size_acceptance_criteria.get(
-            "allowed_margin"
-        ) or 500  # default 500 Bytes
+        allowed_margin = (
+            size_acceptance_criteria.get("allowed_margin") or 500
+        )  # default 500 Bytes
 
         lower_accepted = expected_size - allowed_margin
         upper_accepted = expected_size + allowed_margin
@@ -451,7 +452,6 @@ def assert_sdist_exact_file_structure(tmp_path: Path):
     return _verify_sdist_file_structure
 
 
-
 ######## uv + poetry as build backend ########
 @pytest.fixture(scope="module")
 def sdist_built_at_runtime_with_uv(run_subprocess) -> Path:
@@ -491,7 +491,9 @@ def sdist_built_at_runtime_with_uv(run_subprocess) -> Path:
     print("==========")
     print(result.stderr)
     print("==========")
-    assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}\n"
+    assert (
+        result.exit_code == 0
+    ), f"Expected exit code 0, got {result.exit_code}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}\n"
 
     # THIS IS ONLY FOR UV BUILD CMD
     assert re.search(r"Building source distribution\.\.\.", result.stderr)
@@ -544,7 +546,6 @@ def test_sdist_includes_dirs_and_files_exactly_as_expected_when_produced_via_uv_
     assert_sdist_exact_file_structure(
         sdist_built_at_runtime_with_uv, sdist_expected_correct_file_structure
     )
-
 
 
 ######## Build + poetry as build backend ########

--- a/tests/test_build_backend_sdist.py
+++ b/tests/test_build_backend_sdist.py
@@ -496,7 +496,7 @@ def sdist_built_at_runtime_with_uv(run_subprocess) -> Path:
 
     # THIS IS ONLY FOR UV BUILD CMD
     assert re.search(r"Building source distribution\.\.\.", result.stderr)
-    pattern = r"Successfully built /tmp/dist-unit-test-sdist_built_at_runtime/cookiecutter_python-.+\.tar\.gz"
+    pattern = r"Successfully built .+cookiecutter_python-.+\.tar\.gz"
     assert re.search(pattern, result.stderr)
 
     # After build, retrieve the tar.gz file
@@ -585,7 +585,7 @@ def sdist_built_at_runtime_with_build(run_subprocess) -> Path:
     import re
 
     assert re.search(r"Building sdist\.\.\.", result.stdout)
-    pattern = r"Successfully built .+\.tar\.gz"
+    pattern = r"Successfully built .+cookiecutter_python-.+\.tar\.gz"
     assert re.search(pattern, result.stdout)
 
     # After build, retrieve the tar.gz file

--- a/tests/test_build_backend_sdist.py
+++ b/tests/test_build_backend_sdist.py
@@ -380,16 +380,16 @@ def sdist_expected_correct_file_structure():
 @pytest.fixture
 def verify_file_size_within_acceptable_limits():
     class SizeAcceptanceCriteria(t.TypedDict):
-        expected_size: int
-        allowed_margin: t.Optional[int]
+        expected_size: t.Union[int, float]
+        allowed_margin: t.Optional[t.Union[int, float]]
 
     def _verify_file_size_within_acceptable_limits(
         file: Path, size_acceptance_criteria: SizeAcceptanceCriteria
     ) -> t.Tuple[bool, t.Optional[str]]:
         expected_size = size_acceptance_criteria["expected_size"]
         allowed_margin = size_acceptance_criteria.get(
-            "allowed_margin", 500
-        )  # default 500 Bytes
+            "allowed_margin"
+        ) or 500  # default 500 Bytes
 
         lower_accepted = expected_size - allowed_margin
         upper_accepted = expected_size + allowed_margin
@@ -511,7 +511,7 @@ def test_sdist_tar_gz_file_size_is_within_acceptable_lower_and_upper_limits_when
     # GIVEN we invoke our current build backend to create a source distribution
     sdist_built_at_runtime_with_uv: Path,
     verify_file_size_within_acceptable_limits: t.Callable[
-        [Path, t.Dict[str, int]], t.Tuple[bool, t.Optional[str]]
+        [Path, t.Dict[str, t.Union[int, float]]], t.Tuple[bool, t.Optional[str]]
     ],
 ):
     # Observed: [380KB, 442KB]
@@ -601,7 +601,7 @@ def test_sdist_tar_gz_file_size_is_within_acceptable_lower_and_upper_limits_when
     # GIVEN we invoke our current build backend to create a source distribution
     sdist_built_at_runtime_with_build: Path,
     verify_file_size_within_acceptable_limits: t.Callable[
-        [Path, t.Dict[str, int]], t.Tuple[bool, t.Optional[str]]
+        [Path, t.Dict[str, t.Union[int, float]]], t.Tuple[bool, t.Optional[str]]
     ],
 ):
     # Observed: [379KB, 442KB, 388]

--- a/tests/test_build_backend_sdist.py
+++ b/tests/test_build_backend_sdist.py
@@ -1,0 +1,636 @@
+"""Test building our Source Distribution results in expected File System"""
+
+import typing as t
+import pytest
+from pathlib import Path
+
+
+@pytest.fixture(scope="session")
+def run_subprocess():
+    import subprocess
+    import sys
+    import typing as t
+
+    class CLIResult:
+        def __init__(self, completed_process: subprocess.CompletedProcess):
+            self._exit_code = int(completed_process.returncode)
+            self._stdout = str(completed_process.stdout, encoding='utf-8')
+            self._stderr = str(completed_process.stderr, encoding='utf-8')
+
+        @property
+        def exit_code(self) -> int:
+            return self._exit_code
+
+        @property
+        def stdout(self) -> str:
+            return self._stdout
+
+        @property
+        def stderr(self) -> str:
+            return self._stderr
+
+    def python37_n_above_kwargs():
+        return dict(
+            capture_output=True,  # capture stdout and stderr separately
+            # cwd=project_directory,
+            check=True,
+        )
+
+    def python36_n_below_kwargs():
+        return dict(
+            stdout=subprocess.PIPE,  # capture stdout and stderr separately
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+
+    subprocess_run_map = {
+        True: python36_n_below_kwargs,
+        False: python37_n_above_kwargs,
+    }
+
+    def get_callable(cli_args: t.List[str], **kwargs) -> t.Callable[[], CLIResult]:
+        def subprocess_run() -> CLIResult:
+            kwargs_dict = subprocess_run_map[sys.version_info < (3, 7)]()
+            completed_process = subprocess.run(  # pylint: disable=W1510
+                cli_args, **dict(dict(kwargs_dict, **kwargs))
+            )
+            return CLIResult(completed_process)
+
+        return subprocess_run
+
+    def execute_command_in_subprocess(executable: str, *args, **kwargs):
+        """Run command with python subprocess, given optional runtime arguments.
+
+        Use kwargs to override subprocess flags, such as 'check'
+
+        Flag 'check' defaults to True.
+        """
+        execute_subprocess = get_callable([executable] + list(args), **kwargs)
+        return execute_subprocess()
+
+    return execute_command_in_subprocess
+
+# EXPECTATIONS as fixture
+@pytest.fixture(scope="session")
+def sdist_expected_correct_file_structure():
+    METADATA = (
+        'pyproject.toml',
+        # TODO: generate md files instead of rst!
+        'README.rst',
+        'CHANGELOG.rst',
+        'LICENSE',
+        'CONTRIBUTING.md',
+    )
+    SRC = tuple(
+        [
+            'src/cookiecutter_python/{{ cookiecutter.project_slug }}/' + x
+            for x in METADATA
+        ]
+    ) + (
+        # COOKIECUTTER TEMPLATE
+        'src/cookiecutter_python/cookiecutter.json',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.pkg_name }}/__init__.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.pkg_name }}/__main__.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.pkg_name }}/cli.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.pkg_name }}/_logging.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.pkg_name }}/fixtures.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.pkg_name }}/py.typed',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/tests/conftest.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/tests/smoke_test.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/tests/test_cli.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/tests/test_invoking_cli.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/tests/test_my_fixture.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/.coveragerc',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/.github/labeler.yml',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/.github/workflows/cicd.yml',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/.github/workflows/codecov-upload.yml',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/.github/workflows/labeler.yaml',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/.github/workflows/policy_lint.yml',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/.github/workflows/signal-deploy.yml',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/.github/workflows/test.yaml',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/.gitignore',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/.prospector.yml',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/.pylintrc',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/.readthedocs.yml',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/Dockerfile',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/MANIFEST.in',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/assets/docker_off.png',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/build-process_DAG.md',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/cicd.md',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/cicd_mermaid.md',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/dev_guides/docker.md',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/dev_guides/index.md',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/dockerfile_mermaid.md',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/index.md',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-mkdocs/tags.md',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-sphinx/Makefile',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-sphinx/conf.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-sphinx/contents/10_introduction.rst',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-sphinx/contents/20_why_this_package.rst',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-sphinx/contents/30_usage.rst',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-sphinx/contents/40_modules.rst',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-sphinx/contents/{{ cookiecutter.pkg_name }}.rst',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-sphinx/index.rst',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-sphinx/make.bat',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/docs-sphinx/spelling_wordlist.txt',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/mkdocs.yml',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/scripts/gen_api_refs_pages.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/scripts/parse_version.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/scripts/visualize-dockerfile.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/scripts/visualize-ga-workflow.py',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/setup.cfg',
+        'src/cookiecutter_python/{{ cookiecutter.project_slug }}/tox.ini',
+        'src/cookiecutter_python/__init__.py',
+        'src/cookiecutter_python/__main__.py',
+        'src/cookiecutter_python/cli.py',
+        'src/cookiecutter_python/exceptions.py',
+        'src/cookiecutter_python/utils.py',
+        'src/cookiecutter_python/backend/check_server_result.py',
+        'src/cookiecutter_python/backend/error_handling/handler_builder.py',
+        'src/cookiecutter_python/backend/error_handling/__init__.py',
+        'src/cookiecutter_python/backend/gen_docs_common.py',
+        'src/cookiecutter_python/backend/generator/generator.py',
+        'src/cookiecutter_python/backend/generator/__init__.py',
+        'src/cookiecutter_python/backend/helpers.py',
+        'src/cookiecutter_python/backend/hosting_services/check_engine.py',
+        'src/cookiecutter_python/backend/hosting_services/checker.py',
+        'src/cookiecutter_python/backend/hosting_services/checkers.py',
+        'src/cookiecutter_python/backend/hosting_services/check_service.py',
+        'src/cookiecutter_python/backend/hosting_services/check_web_hosting_service.py',
+        'src/cookiecutter_python/backend/hosting_services/exceptions.py',
+        'src/cookiecutter_python/backend/hosting_services/extract_name.py',
+        'src/cookiecutter_python/backend/hosting_services/handle_hosting_service_check.py',
+        'src/cookiecutter_python/backend/hosting_services/handler.py',
+        'src/cookiecutter_python/backend/hosting_services/__init__.py',
+        'src/cookiecutter_python/backend/hosting_services/value_extractor.py',
+        'src/cookiecutter_python/backend/hosting_services/web_hosting_service.py',
+        'src/cookiecutter_python/backend/__init__.py',
+        'src/cookiecutter_python/backend/load_config.py',
+        'src/cookiecutter_python/backend/main.py',
+        'src/cookiecutter_python/backend/post_main.py',
+        'src/cookiecutter_python/backend/pre_main.py',
+        'src/cookiecutter_python/backend/proxy.py',
+        'src/cookiecutter_python/backend/request.py',
+        'src/cookiecutter_python/backend/sanitization/__init__.py',
+        'src/cookiecutter_python/backend/sanitization/input_sanitization.py',
+        'src/cookiecutter_python/backend/sanitization/interpreters_support.py',
+        'src/cookiecutter_python/backend/sanitization/string_sanitizers/base_sanitizer.py',
+        'src/cookiecutter_python/backend/sanitization/string_sanitizers/__init__.py',
+        'src/cookiecutter_python/backend/sanitization/string_sanitizers/sanitize_reg_input.py',
+        'src/cookiecutter_python/backend/sanitization/string_sanitizers/sanitize_reg_module_name.py',
+        'src/cookiecutter_python/backend/sanitization/string_sanitizers/sanitize_reg_version.py',
+        'src/cookiecutter_python/backend/user_config_proxy.py',
+        'src/cookiecutter_python/cli_handlers.py',
+        'src/cookiecutter_python/exceptions.py',
+        'src/cookiecutter_python/handle/dialogs/dialog.py',
+        'src/cookiecutter_python/handle/dialogs/__init__.py',
+        'src/cookiecutter_python/handle/dialogs/lib/__init__.py',
+        'src/cookiecutter_python/handle/dialogs/lib/project_name.py',
+        'src/cookiecutter_python/handle/__init__.py',
+        'src/cookiecutter_python/handle/interactive_cli_pipeline.py',
+        'src/cookiecutter_python/handle/node_base.py',
+        'src/cookiecutter_python/handle/node_factory.py',
+        'src/cookiecutter_python/handle/node_interface.py',
+        'src/cookiecutter_python/hooks/__init__.py',
+        'src/cookiecutter_python/hooks/post_gen_project.py',
+        'src/cookiecutter_python/hooks/pre_gen_project.py',
+        'src/cookiecutter_python/__init__.py',
+        'src/cookiecutter_python/_logging_config.py',
+        'src/cookiecutter_python/_logging.py',
+        'src/cookiecutter_python/__main__.py',
+        'src/cookiecutter_python/py.typed',
+        'src/cookiecutter_python/utils.py',
+        # 'src/stubs/cookiecutter/config.pyi',
+        # 'src/stubs/cookiecutter/exceptions.pyi',
+        # 'src/stubs/cookiecutter/generate.pyi',
+        # 'src/stubs/cookiecutter/__init__.pyi',
+        # 'src/stubs/cookiecutter/main.pyi',
+        # 'src/stubs/git/exc.pyi',
+        # 'src/stubs/git/__init__.pyi',
+        # 'src/stubs/requests_futures/__init__.pyi',
+        # 'src/stubs/requests_futures/sessions.pyi',
+    )
+    TESTS = (
+        'tests/biskotaki_ci/conftest.py',
+        'tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_build_creates_artifacts.py',
+        'tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py',
+        'tests/biskotaki_ci/snapshot/test_matches_biskotaki_runtime_gen.py',
+        'tests/biskotaki_ci/snapshot/test_valid_ci_config.py',
+        'tests/biskotaki_ci/test_logging.py',
+        'tests/biskotaki_ci/test_regression_biskotaki.py',
+        'tests/conftest.py',
+        'tests/data/biskotaki-with-no-docs-specs.yaml',
+        'tests/data/biskotaki-without-interpreters.yaml',
+        'tests/data/correct_python_package_names.txt',
+        'tests/data/gold-standard.yml',
+        'tests/data/pytest-fixture.yaml',
+        'tests/data/rendering/only_list_template/cookiecutter.json',
+        'tests/data/rendering/only_list_template/{{ cookiecutter.project_dir_name }}/a.txt',
+        'tests/data/rendering/only_list_template/hooks/pre_gen_project.py',
+        'tests/data/rendering/user_config.yml',
+        'tests/data/snapshots/biskotaki-gold-standard/CHANGELOG.rst',
+        'tests/data/snapshots/biskotaki-gold-standard/CONTRIBUTING.md',
+        'tests/data/snapshots/biskotaki-gold-standard/Dockerfile',
+        'tests/data/snapshots/biskotaki-gold-standard/docs/assets/docker_off.png',
+        'tests/data/snapshots/biskotaki-gold-standard/docs/build-process_DAG.md',
+        'tests/data/snapshots/biskotaki-gold-standard/docs/cicd.md',
+        'tests/data/snapshots/biskotaki-gold-standard/docs/cicd_mermaid.md',
+        'tests/data/snapshots/biskotaki-gold-standard/docs/dev_guides/docker.md',
+        'tests/data/snapshots/biskotaki-gold-standard/docs/dev_guides/index.md',
+        'tests/data/snapshots/biskotaki-gold-standard/docs/dockerfile_mermaid.md',
+        'tests/data/snapshots/biskotaki-gold-standard/docs/index.md',
+        'tests/data/snapshots/biskotaki-gold-standard/docs/tags.md',
+        'tests/data/snapshots/biskotaki-gold-standard/LICENSE',
+        'tests/data/snapshots/biskotaki-gold-standard/mkdocs.yml',
+        # 'tests/data/snapshots/biskotaki-gold-standard/poetry.lock',
+        'tests/data/snapshots/biskotaki-gold-standard/pyproject.toml',
+        'tests/data/snapshots/biskotaki-gold-standard/README.rst',
+        'tests/data/snapshots/biskotaki-gold-standard/scripts/gen_api_refs_pages.py',
+        'tests/data/snapshots/biskotaki-gold-standard/scripts/parse_version.py',
+        'tests/data/snapshots/biskotaki-gold-standard/scripts/visualize-dockerfile.py',
+        'tests/data/snapshots/biskotaki-gold-standard/scripts/visualize-ga-workflow.py',
+        'tests/data/snapshots/biskotaki-gold-standard/src/biskotakigold/cli.py',
+        'tests/data/snapshots/biskotaki-gold-standard/src/biskotakigold/__init__.py',
+        'tests/data/snapshots/biskotaki-gold-standard/src/biskotakigold/_logging.py',
+        'tests/data/snapshots/biskotaki-gold-standard/src/biskotakigold/__main__.py',
+        'tests/data/snapshots/biskotaki-gold-standard/src/biskotakigold/py.typed',
+        'tests/data/snapshots/biskotaki-gold-standard/tests/smoke_test.py',
+        'tests/data/snapshots/biskotaki-gold-standard/tests/test_cli.py',
+        'tests/data/snapshots/biskotaki-gold-standard/tests/test_invoking_cli.py',
+        'tests/data/snapshots/biskotaki-gold-standard/tox.ini',
+        'tests/data/snapshots/biskotaki-interactive/CHANGELOG.rst',
+        'tests/data/snapshots/biskotaki-interactive/CONTRIBUTING.md',
+        'tests/data/snapshots/biskotaki-interactive/Dockerfile',
+        'tests/data/snapshots/biskotaki-interactive/docs/conf.py',
+        'tests/data/snapshots/biskotaki-interactive/docs/contents/10_introduction.rst',
+        'tests/data/snapshots/biskotaki-interactive/docs/contents/20_why_this_package.rst',
+        'tests/data/snapshots/biskotaki-interactive/docs/contents/30_usage.rst',
+        'tests/data/snapshots/biskotaki-interactive/docs/contents/40_modules.rst',
+        'tests/data/snapshots/biskotaki-interactive/docs/contents/biskotaki.rst',
+        'tests/data/snapshots/biskotaki-interactive/docs/index.rst',
+        'tests/data/snapshots/biskotaki-interactive/docs/make.bat',
+        'tests/data/snapshots/biskotaki-interactive/docs/Makefile',
+        'tests/data/snapshots/biskotaki-interactive/docs/spelling_wordlist.txt',
+        'tests/data/snapshots/biskotaki-interactive/LICENSE',
+        'tests/data/snapshots/biskotaki-interactive/pyproject.toml',
+        'tests/data/snapshots/biskotaki-interactive/README.rst',
+        'tests/data/snapshots/biskotaki-interactive/scripts/parse_version.py',
+        'tests/data/snapshots/biskotaki-interactive/scripts/visualize-dockerfile.py',
+        'tests/data/snapshots/biskotaki-interactive/scripts/visualize-ga-workflow.py',
+        'tests/data/snapshots/biskotaki-interactive/src/biskotaki/__init__.py',
+        'tests/data/snapshots/biskotaki-interactive/src/biskotaki/_logging.py',
+        'tests/data/snapshots/biskotaki-interactive/src/biskotaki/py.typed',
+        'tests/data/snapshots/biskotaki-interactive/tests/smoke_test.py',
+        'tests/data/snapshots/biskotaki-interactive/tox.ini',
+        'tests/data/snapshots/biskotaki-no-input/CHANGELOG.rst',
+        'tests/data/snapshots/biskotaki-no-input/CONTRIBUTING.md',
+        'tests/data/snapshots/biskotaki-no-input/Dockerfile',
+        'tests/data/snapshots/biskotaki-no-input/docs/conf.py',
+        'tests/data/snapshots/biskotaki-no-input/docs/contents/10_introduction.rst',
+        'tests/data/snapshots/biskotaki-no-input/docs/contents/20_why_this_package.rst',
+        'tests/data/snapshots/biskotaki-no-input/docs/contents/30_usage.rst',
+        'tests/data/snapshots/biskotaki-no-input/docs/contents/40_modules.rst',
+        'tests/data/snapshots/biskotaki-no-input/docs/contents/biskotaki.rst',
+        'tests/data/snapshots/biskotaki-no-input/docs/index.rst',
+        'tests/data/snapshots/biskotaki-no-input/docs/make.bat',
+        'tests/data/snapshots/biskotaki-no-input/docs/Makefile',
+        'tests/data/snapshots/biskotaki-no-input/docs/spelling_wordlist.txt',
+        'tests/data/snapshots/biskotaki-no-input/LICENSE',
+        # probably this was added accidentally, but when there is ci for maintaining modern locks
+        # we shall uncomment
+        # 'tests/data/snapshots/biskotaki-no-input/poetry.lock',
+        'tests/data/snapshots/biskotaki-no-input/pyproject.toml',
+        'tests/data/snapshots/biskotaki-no-input/README.rst',
+        'tests/data/snapshots/biskotaki-no-input/scripts/parse_version.py',
+        'tests/data/snapshots/biskotaki-no-input/scripts/visualize-dockerfile.py',
+        'tests/data/snapshots/biskotaki-no-input/scripts/visualize-ga-workflow.py',
+        'tests/data/snapshots/biskotaki-no-input/src/biskotaki/__init__.py',
+        'tests/data/snapshots/biskotaki-no-input/src/biskotaki/_logging.py',
+        'tests/data/snapshots/biskotaki-no-input/src/biskotaki/py.typed',
+        'tests/data/snapshots/biskotaki-no-input/tests/smoke_test.py',
+        'tests/data/snapshots/biskotaki-no-input/tox.ini',
+        'tests/data/snapshots/README.md',
+        'tests/data/test_cookiecutter.json',
+        'tests/data/snapshots/biskotaki-gold-standard/.coveragerc',
+        'tests/data/snapshots/biskotaki-gold-standard/.github/labeler.yml',
+        'tests/data/snapshots/biskotaki-gold-standard/.github/workflows/cicd.yml',
+        'tests/data/snapshots/biskotaki-gold-standard/.github/workflows/codecov-upload.yml',
+        'tests/data/snapshots/biskotaki-gold-standard/.github/workflows/labeler.yaml',
+        'tests/data/snapshots/biskotaki-gold-standard/.github/workflows/policy_lint.yml',
+        'tests/data/snapshots/biskotaki-gold-standard/.github/workflows/signal-deploy.yml',
+        'tests/data/snapshots/biskotaki-gold-standard/.gitignore',
+        'tests/data/snapshots/biskotaki-gold-standard/.prospector.yml',
+        'tests/data/snapshots/biskotaki-gold-standard/.pylintrc',
+        'tests/data/snapshots/biskotaki-gold-standard/.readthedocs.yml',
+        'tests/data/snapshots/biskotaki-interactive/.coveragerc',
+        'tests/data/snapshots/biskotaki-interactive/.github/labeler.yml',
+        'tests/data/snapshots/biskotaki-interactive/.github/workflows/cicd.yml',
+        'tests/data/snapshots/biskotaki-interactive/.github/workflows/codecov-upload.yml',
+        'tests/data/snapshots/biskotaki-interactive/.github/workflows/labeler.yaml',
+        'tests/data/snapshots/biskotaki-interactive/.github/workflows/policy_lint.yml',
+        'tests/data/snapshots/biskotaki-interactive/.github/workflows/signal-deploy.yml',
+        'tests/data/snapshots/biskotaki-interactive/.gitignore',
+        'tests/data/snapshots/biskotaki-interactive/.prospector.yml',
+        'tests/data/snapshots/biskotaki-interactive/.pylintrc',
+        'tests/data/snapshots/biskotaki-interactive/.readthedocs.yml',
+        'tests/data/snapshots/biskotaki-no-input/.coveragerc',
+        'tests/data/snapshots/biskotaki-no-input/.github/labeler.yml',
+        'tests/data/snapshots/biskotaki-no-input/.github/workflows/cicd.yml',
+        'tests/data/snapshots/biskotaki-no-input/.github/workflows/codecov-upload.yml',
+        'tests/data/snapshots/biskotaki-no-input/.github/workflows/labeler.yaml',
+        'tests/data/snapshots/biskotaki-no-input/.github/workflows/policy_lint.yml',
+        'tests/data/snapshots/biskotaki-no-input/.github/workflows/signal-deploy.yml',
+        'tests/data/snapshots/biskotaki-no-input/.gitignore',
+        'tests/data/snapshots/biskotaki-no-input/.prospector.yml',
+        'tests/data/snapshots/biskotaki-no-input/.pylintrc',
+        'tests/data/snapshots/biskotaki-no-input/.readthedocs.yml',
+        'tests/generator_defaults_shift/test_docs_settings.py',
+        'tests/test_build_backend_sdist.py',
+        'tests/test_ci_pipeline_generation.py',
+        'tests/test_cli.py',
+        'tests/test_cookiecutter_choice_var.py',
+        'tests/test_cookiecutter_context.py',
+        'tests/test_dialog_system.py',
+        'tests/test_docs_gen_feat_compatibillity.py',
+        'tests/test_docs_id_2_folder_mapping.py',
+        'tests/test_error_classifier.py',
+        'tests/test_generate.py',
+        'tests/test_gold_standard.py',
+        'tests/test_module.py',
+        'tests/test_post_gen_hook_regression.py',
+        'tests/test_post_hook.py',
+        'tests/test_prehook.py',
+        'tests/test_running_test_suite.py',
+        'tests/test_sanitization_component.py',
+        'tests/test_sanity.py',
+        'tests/test_snapshot_workflow_yaml.py',
+    )
+    METADATA = (
+        'pyproject.toml',
+        'README.rst',
+        'LICENSE',
+        'CHANGELOG.rst',
+        'CONTRIBUTING.md',
+    )
+    # Injected by Build Backend (Process)
+    ADDED_METADATA = ('PKG-INFO',)
+    return SRC + TESTS + METADATA + ADDED_METADATA
+
+
+@pytest.fixture
+def verify_file_size_within_acceptable_limits():
+    class SizeAcceptanceCriteria(t.TypedDict):
+        expected_size: int
+        allowed_margin: t.Optional[int]
+
+    def _verify_file_size_within_acceptable_limits(
+        file: Path, size_acceptance_criteria: SizeAcceptanceCriteria
+    ) -> t.Tuple[bool, t.Optional[str]]:
+        expected_size = size_acceptance_criteria["expected_size"]
+        allowed_margin = size_acceptance_criteria.get(
+            "allowed_margin", 500
+        )  # default 500 Bytes
+
+        lower_accepted = expected_size - allowed_margin
+        upper_accepted = expected_size + allowed_margin
+
+        runtime_tar_gz_size = file.stat().st_size
+
+        accepted_size: bool = lower_accepted < runtime_tar_gz_size < upper_accepted
+        return accepted_size, (
+            f"Expected Distro to be {expected_size} +- {allowed_margin} Bytes: {lower_accepted} < x < {upper_accepted}. Got {runtime_tar_gz_size} {'>' if runtime_tar_gz_size > upper_accepted else '<'} {'UPPER' if runtime_tar_gz_size > upper_accepted else 'LOWER'}"
+            if not accepted_size
+            else None
+        )
+
+    return _verify_file_size_within_acceptable_limits
+
+
+@pytest.fixture
+def assert_sdist_exact_file_structure(tmp_path: Path):
+    def _verify_sdist_file_structure(
+        sdist_built_at_runtime: Path, expected_file_structure: t.Tuple[str]
+    ):
+        # Extract the tar.gz file to a temporary directory
+        extracted_from_tar_gz = tmp_path / "extracted_from_tar_gz"
+        import tarfile
+
+        with tarfile.open(sdist_built_at_runtime, "r:gz") as tar:
+            tar.extractall(path=extracted_from_tar_gz)
+
+        from cookiecutter_python import __version__
+
+        DISTRO_NAME_AS_IN_SITE_PACKAGES = f'cookiecutter_python-{__version__}'
+
+        # Relative Paths extracted from tar.gz
+        runtime_files = [
+            file.relative_to(extracted_from_tar_gz / DISTRO_NAME_AS_IN_SITE_PACKAGES)
+            for file in extracted_from_tar_gz.rglob("*")
+            if file.is_file()
+        ]
+
+        # Verify all expected files are present
+        missing_files = set(map(Path, expected_file_structure)) - set(runtime_files)
+        assert missing_files == set(), (
+            f"Expected no missing files compared to expected Source Distribution file structure, "
+            f"got [" + '\n'.join(map(str, missing_files)) + "]"
+        )
+
+        # Verify no extra files are present
+        extra_runtime_files = set(runtime_files) - set(
+            map(Path, expected_file_structure)
+        )
+        assert extra_runtime_files == set(), (
+            f"Expected no extra runtime files compared to expectations, "
+            f"got [" + '\n'.join(map(str, sorted(extra_runtime_files))) + "]"
+        )
+
+        # NOW we have asserted that expected and runtime File structure are identical
+
+    return _verify_sdist_file_structure
+
+
+
+######## uv + poetry as build backend ########
+@pytest.fixture(scope="module")
+def sdist_built_at_runtime_with_uv(run_subprocess) -> Path:
+    """Build project (at runtime) with 'uv', and return SDist tar.gz file."""
+    import typing as t
+
+    tmp_path = Path("/tmp")
+    OUT_DIR = tmp_path / "dist-unit-test-sdist_built_at_runtime"
+    # Get distro_path: ie '/site-packages/cookiecutter_python'
+    # import cookiecutter_python
+    # distro_path = Path(cookiecutter_python.__file__).parent.absolute()
+    project_path = Path(__file__).parent.parent
+    import sys
+
+    # result = run_subprocess('uv', 'python', 'pin', sys.executable, check=False)
+    # assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}\n"
+    
+    # invoke uv as build frontend to whatever [build-system] is in pyproject.toml
+    COMMAND_LINE_ARGS: t.List[str] = [
+        # 'uv', 'python', 'pin', sys.executable, '&&',
+        "uv",
+        "build",
+        "--python",
+        sys.executable,
+        "--sdist",
+        "--out-dir",
+        str(OUT_DIR),
+        str(project_path),
+    ]
+    result = run_subprocess(*COMMAND_LINE_ARGS, check=False)
+
+    import re
+
+    print()
+    print("==========")
+    print(result.stdout)
+    print("==========")
+    print(result.stderr)
+    print("==========")
+    assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}\n"
+
+    # THIS IS ONLY FOR UV BUILD CMD
+    assert re.search(r"Building source distribution\.\.\.", result.stderr)
+    pattern = r"Successfully built /tmp/pytest-of-[^/]+/pytest-\d+/test_build_produces_dist_with_\d+/dist-unit-test-sdist_built_at_runtime/cookiecutter_python-\d+\.\d+\.\d+\.tar\.gz"
+    pat = r"Successfully built /tmp/dist-unit-test-sdist_built_at_runtime/cookiecutter_python-.+\.tar\.gz"
+    assert re.search(pat, result.stderr)
+
+    # After build, retrieve the tar.gz file
+    tar_gz_file = list(OUT_DIR.glob("*.tar.gz"))
+    assert len(tar_gz_file) == 1, f"Expected 1 tar.gz file, got {len(tar_gz_file)}"
+    assert tar_gz_file[0].is_file(), f"Expected {tar_gz_file[0]} to be a file"
+    return tar_gz_file[0]
+
+
+## Test SDist Tar GZ file Size is within Acceptable Limits
+@pytest.mark.requires_uv
+def test_sdist_tar_gz_file_size_is_within_acceptable_lower_and_upper_limits_when_produced_via_uv_frontend(
+    # GIVEN we invoke our current build backend to create a source distribution
+    sdist_built_at_runtime_with_uv: Path,
+    verify_file_size_within_acceptable_limits: t.Callable[
+        [Path, t.Dict[str, int]], t.Tuple[bool, t.Optional[str]]
+    ],
+):
+    # Observed: [380KB, 442KB]
+    observations = (
+        380,
+        442,
+    )
+    AVG = sum(observations) / len(observations)
+    tar_gz_file_size_within_acceptable_limits, assertion_error_message = (
+        verify_file_size_within_acceptable_limits(
+            sdist_built_at_runtime_with_uv,
+            {
+                # Observed: [380KB, 442KB]
+                "expected_size": AVG * 1024,  # average of observed sizes
+                "allowed_margin": 100 * 1024,  # 10KB
+            },
+        )
+    )
+    assert tar_gz_file_size_within_acceptable_limits, assertion_error_message
+
+
+## VERIFY SDIST FILE STRUCTURE TO BE EXACTLY AS EXPECTED ##
+@pytest.mark.requires_uv
+def test_sdist_includes_dirs_and_files_exactly_as_expected_when_produced_via_uv_frontend(
+    sdist_built_at_runtime_with_uv: Path,
+    sdist_expected_correct_file_structure: t.Tuple[str],
+    assert_sdist_exact_file_structure,
+):
+    assert_sdist_exact_file_structure(
+        sdist_built_at_runtime_with_uv, sdist_expected_correct_file_structure
+    )
+
+
+
+######## Build + poetry as build backend ########
+@pytest.fixture(scope="module")
+def sdist_built_at_runtime_with_build(run_subprocess) -> Path:
+    """Build project (at runtime) with 'build module', and return SDist tar.gz file."""
+    import typing as t
+
+    tmp_path = Path("/tmp")
+    OUT_DIR = tmp_path / "unit-test-sdist_built_at_runtime_with_build"
+    # Get distro_path: ie '/site-packages/cookiecutter_python'
+    # import cookiecutter_python
+    # distro_path = Path(cookiecutter_python.__file__).parent.absolute()
+    project_path = Path(__file__).parent.parent
+
+    # invoke build module as frontend to whatever [build-system] is in pyproject.toml
+    import sys
+
+    PYTHON = sys.executable  # python from virtualenv
+    COMMAND_LINE_ARGS: t.List[str] = [
+        PYTHON,
+        "-m",
+        "build",
+        "--sdist",
+        "--outdir",
+        str(OUT_DIR),
+        str(project_path),
+    ]
+    result = run_subprocess(*COMMAND_LINE_ARGS, check=False)
+
+    print()
+    print("==========")
+    print(result.stdout)
+    print("==========")
+    print(result.stderr)
+    print("==========")
+    assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}"
+
+    import re
+
+    assert re.search(r"Building sdist\.\.\.", result.stdout)
+    pattern = r"Successfully built .+\.tar\.gz"
+    assert re.search(pattern, result.stdout)
+
+    # After build, retrieve the tar.gz file
+    tar_gz_file = list(OUT_DIR.glob("*.tar.gz"))
+    assert len(tar_gz_file) == 1, f"Expected 1 tar.gz file, got {len(tar_gz_file)}"
+    assert tar_gz_file[0].is_file(), f"Expected {tar_gz_file[0]} to be a file"
+    return tar_gz_file[0]
+
+
+## Test SDist Tar GZ file Size is within Acceptable Limits
+@pytest.mark.slow
+def test_sdist_tar_gz_file_size_is_within_acceptable_lower_and_upper_limits_when_produced_via_build_module_frontend(
+    # GIVEN we invoke our current build backend to create a source distribution
+    sdist_built_at_runtime_with_build: Path,
+    verify_file_size_within_acceptable_limits: t.Callable[
+        [Path, t.Dict[str, int]], t.Tuple[bool, t.Optional[str]]
+    ],
+):
+    # Observed: [379KB, 442KB, 388]
+    observations = (
+        379,
+        442,
+        388,
+    )
+    AVG = sum(observations) / len(observations)
+
+    tar_gz_file_size_within_acceptable_limits, assertion_error_message = (
+        verify_file_size_within_acceptable_limits(
+            sdist_built_at_runtime_with_build,
+            {
+                "expected_size": AVG * 1024,  # Bytes
+                "allowed_margin": 100 * 1024,  # 100KB
+            },
+        )
+    )
+    assert tar_gz_file_size_within_acceptable_limits, assertion_error_message
+
+
+## VERIFY SDIST FILE STRUCTURE TO BE AS EXPECTED ##
+@pytest.mark.slow
+def test_sdist_includes_dirs_and_files_exactly_as_expected_when_produced_via_build_module_frontend(
+    sdist_built_at_runtime_with_build: Path,
+    sdist_expected_correct_file_structure: t.Tuple[str],
+    assert_sdist_exact_file_structure,
+):
+    assert_sdist_exact_file_structure(
+        sdist_built_at_runtime_with_build, sdist_expected_correct_file_structure
+    )

--- a/tests/test_build_backend_sdist.py
+++ b/tests/test_build_backend_sdist.py
@@ -434,8 +434,8 @@ def assert_sdist_exact_file_structure(tmp_path: Path):
         # Verify all expected files are present
         missing_files = set(map(Path, expected_file_structure)) - set(runtime_files)
         assert missing_files == set(), (
-            f"Expected no missing files compared to expected Source Distribution file structure, "
-            f"got [" + '\n'.join(map(str, missing_files)) + "]"
+            "Expected no missing files compared to expected Source Distribution file structure, "
+            "got [" + '\n'.join(map(str, missing_files)) + "]"
         )
 
         # Verify no extra files are present
@@ -443,8 +443,8 @@ def assert_sdist_exact_file_structure(tmp_path: Path):
             map(Path, expected_file_structure)
         )
         assert extra_runtime_files == set(), (
-            f"Expected no extra runtime files compared to expectations, "
-            f"got [" + '\n'.join(map(str, sorted(extra_runtime_files))) + "]"
+            "Expected no extra runtime files compared to expectations, "
+            "got [" + '\n'.join(map(str, sorted(extra_runtime_files))) + "]"
         )
 
         # NOW we have asserted that expected and runtime File structure are identical
@@ -497,9 +497,8 @@ def sdist_built_at_runtime_with_uv(run_subprocess) -> Path:
 
     # THIS IS ONLY FOR UV BUILD CMD
     assert re.search(r"Building source distribution\.\.\.", result.stderr)
-    pattern = r"Successfully built /tmp/pytest-of-[^/]+/pytest-\d+/test_build_produces_dist_with_\d+/dist-unit-test-sdist_built_at_runtime/cookiecutter_python-\d+\.\d+\.\d+\.tar\.gz"
-    pat = r"Successfully built /tmp/dist-unit-test-sdist_built_at_runtime/cookiecutter_python-.+\.tar\.gz"
-    assert re.search(pat, result.stderr)
+    pattern = r"Successfully built /tmp/dist-unit-test-sdist_built_at_runtime/cookiecutter_python-.+\.tar\.gz"
+    assert re.search(pattern, result.stderr)
 
     # After build, retrieve the tar.gz file
     tar_gz_file = list(OUT_DIR.glob("*.tar.gz"))

--- a/tests/test_ci_pipeline_generation.py
+++ b/tests/test_ci_pipeline_generation.py
@@ -45,10 +45,10 @@ def test_file_is_valid_yaml(config_file, user_config, mock_check, tmpdir):
 
     import yaml
 
-    def sanitize_load(s):
+    def sanitize_load(s: str):
         for w in "on".split():
             reg = re.compile(r'^(on):', re.MULTILINE)
-            s: str = reg.sub(r'\1<TEST>:', s)
+            s = reg.sub(r'\1<TEST>:', s)
         # >> Issue: [B506:yaml_load] Use of unsafe yaml load. Allows instantiation of arbitrary objects. Consider yaml.safe_load().
         # Severity: Medium   Confidence: High
         # CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)

--- a/tests/test_ci_pipeline_generation.py
+++ b/tests/test_ci_pipeline_generation.py
@@ -34,7 +34,9 @@ def test_file_is_valid_yaml(config_file, user_config, mock_check, tmpdir):
         default_config=False,
     )
 
-    generate_ci_pipeline_config = Path(project_dir) / '.github' / 'workflows' / 'test.yaml'
+    generate_ci_pipeline_config = (
+        Path(project_dir) / '.github' / 'workflows' / 'test.yaml'
+    )
     assert generate_ci_pipeline_config.exists()
     assert generate_ci_pipeline_config.is_file()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,7 +39,6 @@ class CheckReadthedocsFeatureNotSupported(Exception):
     pass
 
 
-
 # dynamic param 'marks' argument
 tests_root: Path = Path(__file__).parent
 
@@ -66,9 +65,13 @@ RUNNING_FROM_LOCAL_CHECKOUT: bool = (tests_root.parent / '.github').exists()
         ('without-interpreters', False),
         # Test Case 4: pytest-fixture.yaml
         ('tests/data/pytest-fixture.yaml', False),
-        
     ],
-    ids=['biskotaki', 'None', 'without-interpreters', 'pytest-fixture',],
+    ids=[
+        'biskotaki',
+        'None',
+        'without-interpreters',
+        'pytest-fixture',
+    ],
 )
 def test_cli_offline(
     config_file,

--- a/tests/test_cookiecutter_choice_var.py
+++ b/tests/test_cookiecutter_choice_var.py
@@ -37,7 +37,9 @@ def test_calling_cookiecutter_on_prod_template_with_mkdocs_builder(
     # assert expected_default_context_passed['docs_builder'] == 'mkdocs'
     expected_extra_context_passed = None
     if 'interpreters' in user_config_dict:
-        expected_extra_context_passed = {'interpreters': user_config_dict['interpreters']}
+        expected_extra_context_passed = {
+            'interpreters': user_config_dict['interpreters']
+        }
 
     # Track the Jinja Context for SANITY Check
     from cookiecutter.generate import generate_context

--- a/tests/test_cookiecutter_context.py
+++ b/tests/test_cookiecutter_context.py
@@ -337,7 +337,7 @@ default_context:
             ),
             marks=pytest.mark.skipif(
                 not SHOULD_SKIP,
-                reason=f"Test is redundant, since we are running inside project",
+                reason="Test is redundant, since we are running inside project",
             ),
         ),
         (

--- a/tests/test_cookiecutter_context.py
+++ b/tests/test_cookiecutter_context.py
@@ -3,11 +3,11 @@ import typing as t
 from collections import OrderedDict
 from pathlib import Path
 from unittest.mock import patch
-
+import tempfile
 import pytest
 
 MY_DIR = Path(__file__).parent
-CK = 'cookiecutter'  # COOKIECUTTER_KEY
+C_KEY = 'cookiecutter'  # COOKIECUTTER_KEY
 # offest by 2 hours to match Jinja 'now' expression: {% now 'utc', '%Y-%m-%d' %}
 # RELEASE_DATE = (datetime.datetime.now() - datetime.timedelta(hours=2)).strftime('%Y-%m-%d')
 RELEASE_DATE = datetime.datetime.now().strftime('%Y-%m-%d')
@@ -23,6 +23,44 @@ RELEASE_DATE = datetime.datetime.now().strftime('%Y-%m-%d')
 # Verifies cookiecutter.generate_context is called with expected input parameter values
 # Verifies the Jinja Context object generated has the 'cookiecutter' and '_cookiecutter' keys
 # Verifies values of keys are == "exactly equal" to expected values
+
+
+# TEST CASE 2 depends on finding the .github/biskotaki.yaml in local checkout,
+# because its automatic discovery mechanism relies on relative path from this file
+
+TEST_TIME_BISKOTAKI_CONFIG = None
+SHOULD_SKIP = False
+
+if not (MY_DIR.parent / '.github' / 'biskotaki.yaml').exists():
+    SHOULD_SKIP = True
+    # Create a temporary file to use as a test config and PRESERVE it on close!
+    with tempfile.NamedTemporaryFile(mode='w+b', delete=False) as fp:
+        fp.write(b"""
+default_context:
+    project_name: Biskotaki
+    project_type: module
+    project_slug: biskotaki
+    pkg_name: biskotaki
+    repo_name: biskotaki
+    readthedocs_project_slug: biskotaki
+    docker_image: biskotaki
+    full_name: Konstantinos Lampridis
+    author: Konstantinos Lampridis
+    email: k.lampridis@hotmail.com
+    author_email: k.lampridis@hotmail.com
+    github_username: boromir674
+    project_short_description: Project generated using https://github.com/boromir674/cookiecutter-python-package
+    initialize_git_repo: 'no'
+    interpreters: {"supported-interpreters": ["3.7", "3.8", "3.9", "3.10", "3.11"]}
+    ## Documentation Config ##
+    docs_builder: "sphinx"
+    ## READ THE DOCS CI Config ##
+    rtd_python_version: "3.10"
+    cicd: 'experimental'
+
+""")
+        fp.close()
+        TEST_TIME_BISKOTAKI_CONFIG = Path(fp.name)
 
 
 @pytest.fixture(
@@ -61,9 +99,9 @@ RELEASE_DATE = datetime.datetime.now().strftime('%Y-%m-%d')
                 ]
             ),
         ),
-        (
+        pytest.param(
             # TEST CASE 2 - Production Template included in Distribution
-            'PROD_TEMPLATE',  # GIVEN the prod Template (cookiecutter.json + jinja Template project)
+            ('PROD_TEMPLATE',  # GIVEN the prod Template (cookiecutter.json + jinja Template project)
             'BISKOTAKI_CONFIG',  # and the .github/biskotaki.yaml User Config YAML
             # EXPECTED CONTEXT
             OrderedDict(
@@ -149,21 +187,154 @@ RELEASE_DATE = datetime.datetime.now().strftime('%Y-%m-%d')
                                 'yes',
                             ],  # NOTE Difference to 1st Item
                             "interpreters": {
-                                "supported-interpreters": ["3.7", "3.8", "3.9", "3.10", "3.11"]
+                                "supported-interpreters": [
+                                    "3.7",
+                                    "3.8",
+                                    "3.9",
+                                    "3.10",
+                                    "3.11",
+                                ]
                             },
                             "docs_builder": [
                                 'sphinx',
                                 'mkdocs',
                             ],  # NOTE Difference to 1st Item
-                            "rtd_python_version": ["3.10", "3.8", "3.9", "3.11", "3.12"],
+                            "rtd_python_version": [
+                                "3.10",
+                                "3.8",
+                                "3.9",
+                                "3.11",
+                                "3.12",
+                            ],
                             'cicd': ['experimental', 'stable'],
                         },
                     ),
                 ]
-            ),
+            )),
+            marks=pytest.mark.skipif(
+                SHOULD_SKIP,
+                reason=f"'Test is impossible outside of project, automatically replaced by 'test_prod_template' test case. Current path: {MY_DIR}'",
+            )
+        ),
+        pytest.param(
+            # TEST CASE 3 - Production Template included in Distribution
+            ('PROD_TEMPLATE',  # GIVEN the prod Template (cookiecutter.json + jinja Template project)
+            'TEST_TIME_BISKOTAKI_CONFIG',  # and a User Config File that "should be identical" to .github/biskotaki.yaml
+            # EXPECTED CONTEXT
+            OrderedDict(
+                [
+                    # 1st Item mapped in Jinja context with dedicated key
+                    (
+                        'cookiecutter',
+                        OrderedDict(
+                            [
+                                ('project_name', 'Biskotaki'),
+                                ('project_type', 'module'),
+                                ("project_slug", "biskotaki"),
+                                ("pkg_name", "biskotaki"),
+                                ("repo_name", "biskotaki"),
+                                ("readthedocs_project_slug", "biskotaki"),
+                                ("docker_image", "biskotaki"),
+                                ("full_name", "Konstantinos Lampridis"),
+                                ("author", "Konstantinos Lampridis"),
+                                ("author_email", 'k.lampridis@hotmail.com'),
+                                ("github_username", 'boromir674'),
+                                (
+                                    "project_short_description",
+                                    "Project generated using https://github.com/boromir674/cookiecutter-python-package",
+                                ),
+                                (
+                                    "pypi_subtitle",
+                                    "Project generated using https://github.com/boromir674/cookiecutter-python-package",
+                                ),
+                                ("release_date", RELEASE_DATE),
+                                ("year", str(datetime.datetime.now().year)),
+                                ("version", "0.0.1"),
+                                ("initialize_git_repo", "no"),
+                                (
+                                    "interpreters",
+                                    {
+                                        "supported-interpreters": [
+                                            "3.6",
+                                            "3.7",
+                                            "3.8",
+                                            "3.9",
+                                            "3.10",
+                                            "3.11",
+                                        ]
+                                    },
+                                ),
+                                ("docs_builder", "sphinx"),
+                                ("rtd_python_version", "3.10"),
+                                ('cicd', 'experimental'),
+                                # since the below is expected to be put in the extra context before calling cookiecutter, it gets below the rest of Variables
+                                # ('_template', str(cookie)),
+                            ]
+                        ),
+                    ),
+                    # 2nd Item mapped in Jinja context with dedicated key _cookiecutter
+                    (
+                        '_cookiecutter',
+                        {
+                            'project_name': 'Biskotaki',
+                            'project_type': [
+                                'module',
+                                'module+cli',
+                                'pytest-plugin',
+                            ],  # NOTE Difference to 1st Item
+                            "project_slug": "biskotaki",
+                            "pkg_name": "biskotaki",
+                            "repo_name": "biskotaki",
+                            "readthedocs_project_slug": "biskotaki",
+                            "docker_image": "biskotaki",
+                            "full_name": "Konstantinos Lampridis",
+                            "author": "Konstantinos Lampridis",
+                            "author_email": 'k.lampridis@hotmail.com',
+                            "github_username": 'boromir674',
+                            # "project_short_description": "Project generated using https://github.com/boromir674/cookiecutter-python-package",
+                            "project_short_description": "{{ cookiecutter.project_short_description }}",
+                            "pypi_subtitle": "Project generated using https://github.com/boromir674/cookiecutter-python-package",
+                            # current date in format '2024-03-04'
+                            # "release_date": datetime.datetime.now().strftime('%Y-%m-%d'),
+                            "release_date": "{% now 'utc', '%Y-%m-%d' %}",
+                            "year": "{% now 'utc', '%Y' %}",
+                            "version": "0.0.1",
+                            "initialize_git_repo": [
+                                'no',
+                                'yes',
+                            ],  # NOTE Difference to 1st Item
+                            "interpreters": {
+                                "supported-interpreters": [
+                                    "3.7",
+                                    "3.8",
+                                    "3.9",
+                                    "3.10",
+                                    "3.11",
+                                ]
+                            },
+                            "docs_builder": [
+                                'sphinx',
+                                'mkdocs',
+                            ],  # NOTE Difference to 1st Item
+                            "rtd_python_version": [
+                                "3.10",
+                                "3.8",
+                                "3.9",
+                                "3.11",
+                                "3.12",
+                            ],
+                            'cicd': ['experimental', 'stable'],
+                        },
+                    ),
+                ]
+            )),
+            marks=pytest.mark.skipif(
+                not SHOULD_SKIP,
+                reason=f"Test is redundant, since we are running inside project",
+            )
         ),
         (
-            # TEST CASE 3 - Production Template + Gold Standard User Config
+            # TEST CASE 4 - Production Template + Gold Standard User Config
             'PROD_TEMPLATE',  # GIVEN the prod Template (cookiecutter.json + jinja Template project)
             'GOLD_STANDARD_CONFIG',  # and the tests/data/gold-standard.yml
             # EXPECTED CONTEXT
@@ -171,7 +342,7 @@ RELEASE_DATE = datetime.datetime.now().strftime('%Y-%m-%d')
                 [
                     # 1st Item mapped in Jinja context with dedicated key
                     (
-                        CK,
+                        C_KEY,
                         OrderedDict(
                             [
                                 ('project_name', 'Biskotaki Gold Standard'),
@@ -199,7 +370,13 @@ RELEASE_DATE = datetime.datetime.now().strftime('%Y-%m-%d')
                                 ("initialize_git_repo", "no"),
                                 (
                                     "interpreters",
-                                    {"supported-interpreters": ["3.10", "3.11", "3.12"]},
+                                    {
+                                        "supported-interpreters": [
+                                            "3.10",
+                                            "3.11",
+                                            "3.12",
+                                        ]
+                                    },
                                 ),
                                 ("docs_builder", "mkdocs"),
                                 ("rtd_python_version", "3.11"),
@@ -247,7 +424,13 @@ RELEASE_DATE = datetime.datetime.now().strftime('%Y-%m-%d')
                                 'mkdocs',
                                 'sphinx',
                             ],  # NOTE Difference to 1st Item
-                            "rtd_python_version": ["3.11", "3.8", "3.9", "3.10", "3.12"],
+                            "rtd_python_version": [
+                                "3.11",
+                                "3.8",
+                                "3.9",
+                                "3.10",
+                                "3.12",
+                            ],
                             'cicd': ['experimental', 'stable'],
                         },
                     ),
@@ -258,7 +441,8 @@ RELEASE_DATE = datetime.datetime.now().strftime('%Y-%m-%d')
     ids=(
         'simple_template',  # TEST CASE 1
         'prod_template',  # TEST CASE 2
-        'gold_standard',  # TEST CASE 3
+        'test_prod_template',  # TEST CASE 3
+        'gold_standard',  # TEST CASE 4
     ),
 )
 def template_test_case(
@@ -271,19 +455,18 @@ def template_test_case(
     COOKIE_TEMPLATE_DIR: Path = (
         distro_loc if request.param[0] == 'PROD_TEMPLATE' else request.param[0]
     )
-    USER_CONFIG_FILE: Path
+
     # Set User Config YAML
-    if request.param[1] == 'BISKOTAKI_CONFIG':
-        USER_CONFIG_FILE = MY_DIR / '..' / '.github' / 'biskotaki.yaml'
-    elif request.param[1] == 'GOLD_STANDARD_CONFIG':
-        USER_CONFIG_FILE = MY_DIR / 'data' / 'gold-standard.yml'
-    elif request.param[1] == 'PYTEST_PLUGIN_CONFIG':
-        USER_CONFIG_FILE = MY_DIR / 'data' / 'pytest-fixture.yaml'
-    else:
-        USER_CONFIG_FILE = request.param[1]
+    ALIAS_TO_CONFIG_FILE = {
+        'BISKOTAKI_CONFIG': MY_DIR / '..' / '.github' / 'biskotaki.yaml',
+        'TEST_TIME_BISKOTAKI_CONFIG': TEST_TIME_BISKOTAKI_CONFIG,
+        'GOLD_STANDARD_CONFIG': MY_DIR / 'data' / 'gold-standard.yml',
+        'PYTEST_PLUGIN_CONFIG': MY_DIR / 'data' / 'pytest-fixture.yaml',
+    }
+    USER_CONFIG_FILE: Path = ALIAS_TO_CONFIG_FILE.get(request.param[1], request.param[1])
 
     # Prepare Expected Context, produced at runtime by cookiecutter (under the hood)
-    expected_context = request.param[2]
+    expected_context: OrderedDict = request.param[2]
 
     _expected_cookiecutter_parent_dir: str = str(COOKIE_TEMPLATE_DIR)
 
@@ -291,24 +474,25 @@ def template_test_case(
     import os
     import sys
 
-    testing_against_sdist: bool = any([x in os.environ for x in ('PY_SDIST', 'PY_WHEEL')])
+    testing_against_sdist: bool = any(
+        [x in os.environ for x in ('PY_SDIST', 'PY_WHEEL')]
+    )
     if sys.platform == 'win32' and testing_against_sdist:
         # now we allow only the 'expected_cookiecutter_parent_dir' to deviate by 1 letter !!!
         _expected_cookiecutter_parent_dir = _expected_cookiecutter_parent_dir.replace(
             'lib', 'Lib'
         )
 
-    # include template dir or url in the context dict
-    expected_context[CK]['_template'] = _expected_cookiecutter_parent_dir
+    # ADD to Expected CONTEXT (ordered): template dir or url
+    expected_context[C_KEY]['_template'] = _expected_cookiecutter_parent_dir
+    
+    # '_output_dir' key is ADDED HERE (expected_context[C_KEY]['_template']) dynamically
 
-    # include output+dir in the context dict
-    # context[CK]['_output_dir'] = os.path.abspath(output_dir)
+    # ADD to Expected CONTEXT (ordered): include repo dir or url in the context dict
+    expected_context[C_KEY]['_repo_dir'] = _expected_cookiecutter_parent_dir
 
-    # include repo dir or url in the context dict
-    expected_context[CK]['_repo_dir'] = _expected_cookiecutter_parent_dir
-
-    # include checkout details in the context dict
-    expected_context[CK]['_checkout'] = False
+    # ADD to Expected CONTEXT (ordered):  include chec_keyout details in the context dict
+    expected_context[C_KEY]['_checkout'] = False
 
     # manual JSON encoding of 'interpreters', when prod Template + Biskotaki Config
     from cookiecutter_python.backend.load_config import get_interpreters_from_yaml
@@ -320,12 +504,10 @@ def template_test_case(
         assert isinstance(interpreters, dict)
         assert isinstance(interpreters['supported-interpreters'], list)
         assert len(interpreters['supported-interpreters']) > 0
-        expected_context['cookiecutter']['interpreters'] = interpreters
+        # ADD to Expected CONTEXT (ordered): interpreters
+        expected_context[C_KEY]['interpreters'] = interpreters
 
     COOKIECUTTER_CALLABLE: t.Callable
-
-    # Add the '_template' key to the expected context, like cookiecutter does
-    expected_context['cookiecutter']['_template'] = _expected_cookiecutter_parent_dir
 
     if request.param[0] == 'PROD_TEMPLATE':
         assert isinstance(interpreters, dict)
@@ -352,10 +534,26 @@ def template_test_case(
 
         COOKIECUTTER_CALLABLE = _generate_callback
 
+    def get_expected_context(folder_path: Path):
+        def gen():
+            # generator keys an inject _output_dir
+            for k, v in expected_context[C_KEY].items():
+                # if key is not _template, yield it
+                if k != '_template':
+                    yield k, v
+                # if key is _template, yield it and then yield _output_dir
+                else:
+                    yield k, v
+                    yield '_output_dir', str(folder_path.absolute())
+        return OrderedDict([
+            (C_KEY, OrderedDict([(k, v) for k, v in gen()])),
+            ('_cookiecutter', expected_context['_cookiecutter']),
+        ])
+
     return {
         'cookie': COOKIE_TEMPLATE_DIR,
         'user_config': USER_CONFIG_FILE,
-        'expected_context': expected_context,
+        'get_expected_context': get_expected_context,
         'cookiecutter_callback': COOKIECUTTER_CALLABLE,
     }
 
@@ -378,46 +576,27 @@ def test_cookiecutter_generates_context_with_expected_values(
     gen_proj_dir: Path = tmp_path
     assert gen_proj_dir.exists() and len(list(gen_proj_dir.iterdir())) == 0
 
-    # UPDATE EXPECTATION (todo move outside of this Test Case, into Data block)
-    # template_test_case['expected_context'][CK]['_output_dir'] = str(gen_proj_dir.absolute())
-    # build new Ordered Dict since _output_dir needs to be between _template and _repo_dir
-    def gen():
-        # generator keys an inject _output_dir
-        for k, v in template_test_case['expected_context'][CK].items():
-            # if key is not _template, yield it
-            if k != '_template':
-                yield k, v
-            # if key is _template, yield it and then yield _output_dir
-            else:
-                yield k, v
-                yield '_output_dir', str(gen_proj_dir.absolute())
-
-    patched_CK_context = OrderedDict([(k, v) for k, v in gen()])
-    template_test_case['expected_context'][CK] = patched_CK_context
+    # GIVEN the EXPECTED CONTEXT DISCTIONARY
+    EXPECTED_CONTEXT = template_test_case['get_expected_context'](gen_proj_dir)
 
     # GIVEN a way to "track" the input passed at runtime to cookiecutter's generate_context function
-
-    # Define parameter values expected to be passed at runtime to cookiecutter's generate_context function
-    # expected to be passed as kwargs
-    # str(cookie / 'cookiecutter.json')
-    expected_context_file_passed = template_test_case['expected_context']['cookiecutter'][
-        '_template'
-    ]
-
     from cookiecutter.config import get_config
 
     user_config_dict = get_config(config_yaml)
     expected_default_context_passed = user_config_dict['default_context']
 
     expected_extra_context_passed = None
-    if 'interpreters' in template_test_case['expected_context']['cookiecutter']:
+    if 'interpreters' in EXPECTED_CONTEXT['cookiecutter']:
         expected_extra_context_passed = {
-            'interpreters': template_test_case['expected_context']['cookiecutter'][
+            'interpreters': EXPECTED_CONTEXT['cookiecutter'][
                 'interpreters'
             ]
         }
 
     from cookiecutter.generate import generate_context
+
+    # SANITY no calls to generate_context yet
+    assert generate_context_mock.call_count == 0
 
     prod_result = generate_context(
         context_file=str(cookie / 'cookiecutter.json'),
@@ -425,7 +604,10 @@ def test_cookiecutter_generates_context_with_expected_values(
         extra_context=expected_extra_context_passed,
     )
 
-    # assert prod_result == template_test_case['expected_context']
+    # SANITY no calls to generate_context yet
+    assert generate_context_mock.call_count == 0
+
+    # assert prod_result == EXPECTED_CONTEXT
 
     # WHEN cookiecutter is called (either directly or via Generator) on a Template
     # and with the User Config YAML
@@ -436,13 +618,13 @@ def test_cookiecutter_generates_context_with_expected_values(
         config_file=str(config_yaml),
         default_config=False,
         output_dir=gen_proj_dir,
-        # extra_context={'interpreters': template_test_case['expected_context']['cookiecutter']['interpreters']} if 'interpreters' in template_test_case['expected_context']['cookiecutter'] else None,
+        # extra_context={'interpreters': EXPECTED_CONTEXT['cookiecutter']['interpreters']} if 'interpreters' in EXPECTED_CONTEXT['cookiecutter'] else None,
         no_input=True,  # non interactive
         checkout=False,
         replay=False,
     )
 
-    # THEN the Context was generated once
+    # THEN the generate_context was called once
     assert generate_context_mock.call_count == 1
     generate_context_mock.assert_called_once()
 
@@ -450,7 +632,7 @@ def test_cookiecutter_generates_context_with_expected_values(
     # THEN the internal generate_context of coociecutter was called with expected runtime input values
 
     generate_context_mock.assert_called_with(
-        context_file=str(Path(expected_context_file_passed) / 'cookiecutter.json'),
+        context_file=str(Path(EXPECTED_CONTEXT['cookiecutter']['_template']) / 'cookiecutter.json'),
         default_context=expected_default_context_passed,
         extra_context=expected_extra_context_passed,
     )
@@ -459,24 +641,29 @@ def test_cookiecutter_generates_context_with_expected_values(
 
     # SANITY check User Config YAML data passed as Dict to 'default_context' kwarg of generate_context
     assert expected_default_context_passed == OrderedDict(
-        [(k, v) for k, v in yaml.safe_load(config_yaml.read_text())['default_context'].items()]
+        [
+            (k, v)
+            for k, v in yaml.safe_load(config_yaml.read_text())[
+                'default_context'
+            ].items()
+        ]
     )
     # AND Cookiecutter inserts 2 keys into Jinja Context: 'cookiecutter' and '_cookiecutter'
-    assert set(prod_result.keys()) == {CK, '_cookiecutter'}
+    assert set(prod_result.keys()) == {C_KEY, '_cookiecutter'}
 
     # AND the Template Variables in 'cookiecutter' key is an OrderedDict
-    assert isinstance(prod_result[CK], OrderedDict)
+    assert isinstance(prod_result[C_KEY], OrderedDict)
 
     # AND the internal data in jinja context map under 'cookiecutter' key are as expected
-    assert len(prod_result[CK]) == len(template_test_case['expected_context'][CK])
+    assert len(prod_result[C_KEY]) == len(EXPECTED_CONTEXT[C_KEY])
     for p1, p2 in zip(
-        prod_result[CK].items(), template_test_case['expected_context'][CK].items()
+        prod_result[C_KEY].items(), EXPECTED_CONTEXT[C_KEY].items()
     ):
         assert p1[0] == p2[0], (
             "All PROD Keys: [\n"
-            + '\n'.join(prod_result[CK].keys())
+            + '\n'.join(prod_result[C_KEY].keys())
             + '\n]\n\nAll TEST Keys: [\n'
-            + '\n'.join(template_test_case['expected_context'][CK].keys())
+            + '\n'.join(EXPECTED_CONTEXT[C_KEY].keys())
             + "\n]"
         )
         if p1[0] == 'release_date':
@@ -490,19 +677,19 @@ def test_cookiecutter_generates_context_with_expected_values(
                     - datetime.datetime.strptime(expected_date, '%Y-%m-%d')
                 ).days
                 <= 1
-            ), f"Context Missmatch at '{CK}' -> '{p1[0]}': Runtime: '{runtime_date}', Expected: '{expected_date}'"
+            ), f"Context Missmatch at '{C_KEY}' -> '{p1[0]}': Runtime: '{runtime_date}', Expected: '{expected_date}'"
         else:
             assert (
                 p1[1] == p2[1]
-            ), f"Context Missmatch at '{CK}' -> '{p1[0]}': Runtime: '{p1[1]}', Expected: '{p2[1]}'"
+            ), f"Context Missmatch at '{C_KEY}' -> '{p1[0]}': Runtime: '{p1[1]}', Expected: '{p2[1]}'"
 
-    assert prod_result[CK] == dict(
-        template_test_case['expected_context'][CK],
+    assert prod_result[C_KEY] == dict(
+        EXPECTED_CONTEXT[C_KEY],
         **(
             {
-                'release_date': prod_result[CK]['release_date'],
+                'release_date': prod_result[C_KEY]['release_date'],
             }
-            if 'release_date' in prod_result[CK]
+            if 'release_date' in prod_result[C_KEY]
             else {}
         ),
     )
@@ -512,13 +699,15 @@ def test_cookiecutter_generates_context_with_expected_values(
 
     # AND the internal data in jinja context map under '_cookiecutter' key are as expected
     assert len(prod_result['_cookiecutter']) == len(
-        template_test_case['expected_context']['_cookiecutter']
+        EXPECTED_CONTEXT['_cookiecutter']
     )
     for p1, p2 in zip(
         prod_result['_cookiecutter'].items(),
-        template_test_case['expected_context']['_cookiecutter'].items(),
+        EXPECTED_CONTEXT['_cookiecutter'].items(),
     ):
         assert p1[0] == p2[0]
         if p1[0] in {'project_short_description', 'pypi_subtitle'}:
             continue
-        assert p1[1] == p2[1], f"Error at key {p1[0]} with value {p1[1]}! Expected {p2[1]}!"
+        assert (
+            p1[1] == p2[1]
+        ), f"Error at key {p1[0]} with value {p1[1]}! Expected {p2[1]}!"

--- a/tests/test_cookiecutter_context.py
+++ b/tests/test_cookiecutter_context.py
@@ -440,7 +440,7 @@ default_context:
     ],
     ids=(
         'simple_template',  # TEST CASE 1
-        'prod_template',  # TEST CASE 2
+        'prod_template',  # TEST CASE 2 (mutually exclusinve with Test Case 3)
         'test_prod_template',  # TEST CASE 3
         'gold_standard',  # TEST CASE 4
     ),
@@ -457,13 +457,14 @@ def template_test_case(
     )
 
     # Set User Config YAML
-    ALIAS_TO_CONFIG_FILE = {
+    ALIAS_TO_CONFIG_FILE: t.Dict[str, t.Optional[Path]] = {
         'BISKOTAKI_CONFIG': MY_DIR / '..' / '.github' / 'biskotaki.yaml',
         'TEST_TIME_BISKOTAKI_CONFIG': TEST_TIME_BISKOTAKI_CONFIG,
         'GOLD_STANDARD_CONFIG': MY_DIR / 'data' / 'gold-standard.yml',
         'PYTEST_PLUGIN_CONFIG': MY_DIR / 'data' / 'pytest-fixture.yaml',
     }
-    USER_CONFIG_FILE: Path = ALIAS_TO_CONFIG_FILE.get(request.param[1], request.param[1])
+
+    USER_CONFIG_FILE = ALIAS_TO_CONFIG_FILE.get(request.param[1], request.param[1])
 
     # Prepare Expected Context, produced at runtime by cookiecutter (under the hood)
     expected_context: OrderedDict = request.param[2]

--- a/tests/test_cookiecutter_context.py
+++ b/tests/test_cookiecutter_context.py
@@ -1,9 +1,10 @@
 import datetime
+import tempfile
 import typing as t
 from collections import OrderedDict
 from pathlib import Path
 from unittest.mock import patch
-import tempfile
+
 import pytest
 
 MY_DIR = Path(__file__).parent

--- a/tests/test_cookiecutter_context.py
+++ b/tests/test_cookiecutter_context.py
@@ -36,7 +36,8 @@ if not (MY_DIR.parent / '.github' / 'biskotaki.yaml').exists():
     SHOULD_SKIP = True
     # Create a temporary file to use as a test config and PRESERVE it on close!
     with tempfile.NamedTemporaryFile(mode='w+b', delete=False) as fp:
-        fp.write(b"""
+        fp.write(
+            b"""
 default_context:
     project_name: Biskotaki
     project_type: module
@@ -59,7 +60,8 @@ default_context:
     rtd_python_version: "3.10"
     cicd: 'experimental'
 
-""")
+"""
+        )
         fp.close()
         TEST_TIME_BISKOTAKI_CONFIG = Path(fp.name)
 
@@ -102,237 +104,241 @@ default_context:
         ),
         pytest.param(
             # TEST CASE 2 - Production Template included in Distribution
-            ('PROD_TEMPLATE',  # GIVEN the prod Template (cookiecutter.json + jinja Template project)
-            'BISKOTAKI_CONFIG',  # and the .github/biskotaki.yaml User Config YAML
-            # EXPECTED CONTEXT
-            OrderedDict(
-                [
-                    # 1st Item mapped in Jinja context with dedicated key
-                    (
-                        'cookiecutter',
-                        OrderedDict(
-                            [
-                                ('project_name', 'Biskotaki'),
-                                ('project_type', 'module'),
-                                ("project_slug", "biskotaki"),
-                                ("pkg_name", "biskotaki"),
-                                ("repo_name", "biskotaki"),
-                                ("readthedocs_project_slug", "biskotaki"),
-                                ("docker_image", "biskotaki"),
-                                ("full_name", "Konstantinos Lampridis"),
-                                ("author", "Konstantinos Lampridis"),
-                                ("author_email", 'k.lampridis@hotmail.com'),
-                                ("github_username", 'boromir674'),
-                                (
-                                    "project_short_description",
-                                    "Project generated using https://github.com/boromir674/cookiecutter-python-package",
-                                ),
-                                (
-                                    "pypi_subtitle",
-                                    "Project generated using https://github.com/boromir674/cookiecutter-python-package",
-                                ),
-                                ("release_date", RELEASE_DATE),
-                                ("year", str(datetime.datetime.now().year)),
-                                ("version", "0.0.1"),
-                                ("initialize_git_repo", "no"),
-                                (
-                                    "interpreters",
-                                    {
-                                        "supported-interpreters": [
-                                            "3.6",
-                                            "3.7",
-                                            "3.8",
-                                            "3.9",
-                                            "3.10",
-                                            "3.11",
-                                        ]
-                                    },
-                                ),
-                                ("docs_builder", "sphinx"),
-                                ("rtd_python_version", "3.10"),
-                                ('cicd', 'experimental'),
-                                # since the below is expected to be put in the extra context before calling cookiecutter, it gets below the rest of Variables
-                                # ('_template', str(cookie)),
-                            ]
+            (
+                'PROD_TEMPLATE',  # GIVEN the prod Template (cookiecutter.json + jinja Template project)
+                'BISKOTAKI_CONFIG',  # and the .github/biskotaki.yaml User Config YAML
+                # EXPECTED CONTEXT
+                OrderedDict(
+                    [
+                        # 1st Item mapped in Jinja context with dedicated key
+                        (
+                            'cookiecutter',
+                            OrderedDict(
+                                [
+                                    ('project_name', 'Biskotaki'),
+                                    ('project_type', 'module'),
+                                    ("project_slug", "biskotaki"),
+                                    ("pkg_name", "biskotaki"),
+                                    ("repo_name", "biskotaki"),
+                                    ("readthedocs_project_slug", "biskotaki"),
+                                    ("docker_image", "biskotaki"),
+                                    ("full_name", "Konstantinos Lampridis"),
+                                    ("author", "Konstantinos Lampridis"),
+                                    ("author_email", 'k.lampridis@hotmail.com'),
+                                    ("github_username", 'boromir674'),
+                                    (
+                                        "project_short_description",
+                                        "Project generated using https://github.com/boromir674/cookiecutter-python-package",
+                                    ),
+                                    (
+                                        "pypi_subtitle",
+                                        "Project generated using https://github.com/boromir674/cookiecutter-python-package",
+                                    ),
+                                    ("release_date", RELEASE_DATE),
+                                    ("year", str(datetime.datetime.now().year)),
+                                    ("version", "0.0.1"),
+                                    ("initialize_git_repo", "no"),
+                                    (
+                                        "interpreters",
+                                        {
+                                            "supported-interpreters": [
+                                                "3.6",
+                                                "3.7",
+                                                "3.8",
+                                                "3.9",
+                                                "3.10",
+                                                "3.11",
+                                            ]
+                                        },
+                                    ),
+                                    ("docs_builder", "sphinx"),
+                                    ("rtd_python_version", "3.10"),
+                                    ('cicd', 'experimental'),
+                                    # since the below is expected to be put in the extra context before calling cookiecutter, it gets below the rest of Variables
+                                    # ('_template', str(cookie)),
+                                ]
+                            ),
                         ),
-                    ),
-                    # 2nd Item mapped in Jinja context with dedicated key _cookiecutter
-                    (
-                        '_cookiecutter',
-                        {
-                            'project_name': 'Biskotaki',
-                            'project_type': [
-                                'module',
-                                'module+cli',
-                                'pytest-plugin',
-                            ],  # NOTE Difference to 1st Item
-                            "project_slug": "biskotaki",
-                            "pkg_name": "biskotaki",
-                            "repo_name": "biskotaki",
-                            "readthedocs_project_slug": "biskotaki",
-                            "docker_image": "biskotaki",
-                            "full_name": "Konstantinos Lampridis",
-                            "author": "Konstantinos Lampridis",
-                            "author_email": 'k.lampridis@hotmail.com',
-                            "github_username": 'boromir674',
-                            # "project_short_description": "Project generated using https://github.com/boromir674/cookiecutter-python-package",
-                            "project_short_description": "{{ cookiecutter.project_short_description }}",
-                            "pypi_subtitle": "Project generated using https://github.com/boromir674/cookiecutter-python-package",
-                            # current date in format '2024-03-04'
-                            # "release_date": datetime.datetime.now().strftime('%Y-%m-%d'),
-                            "release_date": "{% now 'utc', '%Y-%m-%d' %}",
-                            "year": "{% now 'utc', '%Y' %}",
-                            "version": "0.0.1",
-                            "initialize_git_repo": [
-                                'no',
-                                'yes',
-                            ],  # NOTE Difference to 1st Item
-                            "interpreters": {
-                                "supported-interpreters": [
-                                    "3.7",
+                        # 2nd Item mapped in Jinja context with dedicated key _cookiecutter
+                        (
+                            '_cookiecutter',
+                            {
+                                'project_name': 'Biskotaki',
+                                'project_type': [
+                                    'module',
+                                    'module+cli',
+                                    'pytest-plugin',
+                                ],  # NOTE Difference to 1st Item
+                                "project_slug": "biskotaki",
+                                "pkg_name": "biskotaki",
+                                "repo_name": "biskotaki",
+                                "readthedocs_project_slug": "biskotaki",
+                                "docker_image": "biskotaki",
+                                "full_name": "Konstantinos Lampridis",
+                                "author": "Konstantinos Lampridis",
+                                "author_email": 'k.lampridis@hotmail.com',
+                                "github_username": 'boromir674',
+                                # "project_short_description": "Project generated using https://github.com/boromir674/cookiecutter-python-package",
+                                "project_short_description": "{{ cookiecutter.project_short_description }}",
+                                "pypi_subtitle": "Project generated using https://github.com/boromir674/cookiecutter-python-package",
+                                # current date in format '2024-03-04'
+                                # "release_date": datetime.datetime.now().strftime('%Y-%m-%d'),
+                                "release_date": "{% now 'utc', '%Y-%m-%d' %}",
+                                "year": "{% now 'utc', '%Y' %}",
+                                "version": "0.0.1",
+                                "initialize_git_repo": [
+                                    'no',
+                                    'yes',
+                                ],  # NOTE Difference to 1st Item
+                                "interpreters": {
+                                    "supported-interpreters": [
+                                        "3.7",
+                                        "3.8",
+                                        "3.9",
+                                        "3.10",
+                                        "3.11",
+                                    ]
+                                },
+                                "docs_builder": [
+                                    'sphinx',
+                                    'mkdocs',
+                                ],  # NOTE Difference to 1st Item
+                                "rtd_python_version": [
+                                    "3.10",
                                     "3.8",
                                     "3.9",
-                                    "3.10",
                                     "3.11",
-                                ]
+                                    "3.12",
+                                ],
+                                'cicd': ['experimental', 'stable'],
                             },
-                            "docs_builder": [
-                                'sphinx',
-                                'mkdocs',
-                            ],  # NOTE Difference to 1st Item
-                            "rtd_python_version": [
-                                "3.10",
-                                "3.8",
-                                "3.9",
-                                "3.11",
-                                "3.12",
-                            ],
-                            'cicd': ['experimental', 'stable'],
-                        },
-                    ),
-                ]
-            )),
+                        ),
+                    ]
+                ),
+            ),
             marks=pytest.mark.skipif(
                 SHOULD_SKIP,
                 reason=f"'Test is impossible outside of project, automatically replaced by 'test_prod_template' test case. Current path: {MY_DIR}'",
-            )
+            ),
         ),
         pytest.param(
             # TEST CASE 3 - Production Template included in Distribution
-            ('PROD_TEMPLATE',  # GIVEN the prod Template (cookiecutter.json + jinja Template project)
-            'TEST_TIME_BISKOTAKI_CONFIG',  # and a User Config File that "should be identical" to .github/biskotaki.yaml
-            # EXPECTED CONTEXT
-            OrderedDict(
-                [
-                    # 1st Item mapped in Jinja context with dedicated key
-                    (
-                        'cookiecutter',
-                        OrderedDict(
-                            [
-                                ('project_name', 'Biskotaki'),
-                                ('project_type', 'module'),
-                                ("project_slug", "biskotaki"),
-                                ("pkg_name", "biskotaki"),
-                                ("repo_name", "biskotaki"),
-                                ("readthedocs_project_slug", "biskotaki"),
-                                ("docker_image", "biskotaki"),
-                                ("full_name", "Konstantinos Lampridis"),
-                                ("author", "Konstantinos Lampridis"),
-                                ("author_email", 'k.lampridis@hotmail.com'),
-                                ("github_username", 'boromir674'),
-                                (
-                                    "project_short_description",
-                                    "Project generated using https://github.com/boromir674/cookiecutter-python-package",
-                                ),
-                                (
-                                    "pypi_subtitle",
-                                    "Project generated using https://github.com/boromir674/cookiecutter-python-package",
-                                ),
-                                ("release_date", RELEASE_DATE),
-                                ("year", str(datetime.datetime.now().year)),
-                                ("version", "0.0.1"),
-                                ("initialize_git_repo", "no"),
-                                (
-                                    "interpreters",
-                                    {
-                                        "supported-interpreters": [
-                                            "3.6",
-                                            "3.7",
-                                            "3.8",
-                                            "3.9",
-                                            "3.10",
-                                            "3.11",
-                                        ]
-                                    },
-                                ),
-                                ("docs_builder", "sphinx"),
-                                ("rtd_python_version", "3.10"),
-                                ('cicd', 'experimental'),
-                                # since the below is expected to be put in the extra context before calling cookiecutter, it gets below the rest of Variables
-                                # ('_template', str(cookie)),
-                            ]
+            (
+                'PROD_TEMPLATE',  # GIVEN the prod Template (cookiecutter.json + jinja Template project)
+                'TEST_TIME_BISKOTAKI_CONFIG',  # and a User Config File that "should be identical" to .github/biskotaki.yaml
+                # EXPECTED CONTEXT
+                OrderedDict(
+                    [
+                        # 1st Item mapped in Jinja context with dedicated key
+                        (
+                            'cookiecutter',
+                            OrderedDict(
+                                [
+                                    ('project_name', 'Biskotaki'),
+                                    ('project_type', 'module'),
+                                    ("project_slug", "biskotaki"),
+                                    ("pkg_name", "biskotaki"),
+                                    ("repo_name", "biskotaki"),
+                                    ("readthedocs_project_slug", "biskotaki"),
+                                    ("docker_image", "biskotaki"),
+                                    ("full_name", "Konstantinos Lampridis"),
+                                    ("author", "Konstantinos Lampridis"),
+                                    ("author_email", 'k.lampridis@hotmail.com'),
+                                    ("github_username", 'boromir674'),
+                                    (
+                                        "project_short_description",
+                                        "Project generated using https://github.com/boromir674/cookiecutter-python-package",
+                                    ),
+                                    (
+                                        "pypi_subtitle",
+                                        "Project generated using https://github.com/boromir674/cookiecutter-python-package",
+                                    ),
+                                    ("release_date", RELEASE_DATE),
+                                    ("year", str(datetime.datetime.now().year)),
+                                    ("version", "0.0.1"),
+                                    ("initialize_git_repo", "no"),
+                                    (
+                                        "interpreters",
+                                        {
+                                            "supported-interpreters": [
+                                                "3.6",
+                                                "3.7",
+                                                "3.8",
+                                                "3.9",
+                                                "3.10",
+                                                "3.11",
+                                            ]
+                                        },
+                                    ),
+                                    ("docs_builder", "sphinx"),
+                                    ("rtd_python_version", "3.10"),
+                                    ('cicd', 'experimental'),
+                                    # since the below is expected to be put in the extra context before calling cookiecutter, it gets below the rest of Variables
+                                    # ('_template', str(cookie)),
+                                ]
+                            ),
                         ),
-                    ),
-                    # 2nd Item mapped in Jinja context with dedicated key _cookiecutter
-                    (
-                        '_cookiecutter',
-                        {
-                            'project_name': 'Biskotaki',
-                            'project_type': [
-                                'module',
-                                'module+cli',
-                                'pytest-plugin',
-                            ],  # NOTE Difference to 1st Item
-                            "project_slug": "biskotaki",
-                            "pkg_name": "biskotaki",
-                            "repo_name": "biskotaki",
-                            "readthedocs_project_slug": "biskotaki",
-                            "docker_image": "biskotaki",
-                            "full_name": "Konstantinos Lampridis",
-                            "author": "Konstantinos Lampridis",
-                            "author_email": 'k.lampridis@hotmail.com',
-                            "github_username": 'boromir674',
-                            # "project_short_description": "Project generated using https://github.com/boromir674/cookiecutter-python-package",
-                            "project_short_description": "{{ cookiecutter.project_short_description }}",
-                            "pypi_subtitle": "Project generated using https://github.com/boromir674/cookiecutter-python-package",
-                            # current date in format '2024-03-04'
-                            # "release_date": datetime.datetime.now().strftime('%Y-%m-%d'),
-                            "release_date": "{% now 'utc', '%Y-%m-%d' %}",
-                            "year": "{% now 'utc', '%Y' %}",
-                            "version": "0.0.1",
-                            "initialize_git_repo": [
-                                'no',
-                                'yes',
-                            ],  # NOTE Difference to 1st Item
-                            "interpreters": {
-                                "supported-interpreters": [
-                                    "3.7",
+                        # 2nd Item mapped in Jinja context with dedicated key _cookiecutter
+                        (
+                            '_cookiecutter',
+                            {
+                                'project_name': 'Biskotaki',
+                                'project_type': [
+                                    'module',
+                                    'module+cli',
+                                    'pytest-plugin',
+                                ],  # NOTE Difference to 1st Item
+                                "project_slug": "biskotaki",
+                                "pkg_name": "biskotaki",
+                                "repo_name": "biskotaki",
+                                "readthedocs_project_slug": "biskotaki",
+                                "docker_image": "biskotaki",
+                                "full_name": "Konstantinos Lampridis",
+                                "author": "Konstantinos Lampridis",
+                                "author_email": 'k.lampridis@hotmail.com',
+                                "github_username": 'boromir674',
+                                # "project_short_description": "Project generated using https://github.com/boromir674/cookiecutter-python-package",
+                                "project_short_description": "{{ cookiecutter.project_short_description }}",
+                                "pypi_subtitle": "Project generated using https://github.com/boromir674/cookiecutter-python-package",
+                                # current date in format '2024-03-04'
+                                # "release_date": datetime.datetime.now().strftime('%Y-%m-%d'),
+                                "release_date": "{% now 'utc', '%Y-%m-%d' %}",
+                                "year": "{% now 'utc', '%Y' %}",
+                                "version": "0.0.1",
+                                "initialize_git_repo": [
+                                    'no',
+                                    'yes',
+                                ],  # NOTE Difference to 1st Item
+                                "interpreters": {
+                                    "supported-interpreters": [
+                                        "3.7",
+                                        "3.8",
+                                        "3.9",
+                                        "3.10",
+                                        "3.11",
+                                    ]
+                                },
+                                "docs_builder": [
+                                    'sphinx',
+                                    'mkdocs',
+                                ],  # NOTE Difference to 1st Item
+                                "rtd_python_version": [
+                                    "3.10",
                                     "3.8",
                                     "3.9",
-                                    "3.10",
                                     "3.11",
-                                ]
+                                    "3.12",
+                                ],
+                                'cicd': ['experimental', 'stable'],
                             },
-                            "docs_builder": [
-                                'sphinx',
-                                'mkdocs',
-                            ],  # NOTE Difference to 1st Item
-                            "rtd_python_version": [
-                                "3.10",
-                                "3.8",
-                                "3.9",
-                                "3.11",
-                                "3.12",
-                            ],
-                            'cicd': ['experimental', 'stable'],
-                        },
-                    ),
-                ]
-            )),
+                        ),
+                    ]
+                ),
+            ),
             marks=pytest.mark.skipif(
                 not SHOULD_SKIP,
                 reason=f"Test is redundant, since we are running inside project",
-            )
+            ),
         ),
         (
             # TEST CASE 4 - Production Template + Gold Standard User Config
@@ -487,7 +493,7 @@ def template_test_case(
 
     # ADD to Expected CONTEXT (ordered): template dir or url
     expected_context[C_KEY]['_template'] = _expected_cookiecutter_parent_dir
-    
+
     # '_output_dir' key is ADDED HERE (expected_context[C_KEY]['_template']) dynamically
 
     # ADD to Expected CONTEXT (ordered): include repo dir or url in the context dict
@@ -547,10 +553,13 @@ def template_test_case(
                 else:
                     yield k, v
                     yield '_output_dir', str(folder_path.absolute())
-        return OrderedDict([
-            (C_KEY, OrderedDict([(k, v) for k, v in gen()])),
-            ('_cookiecutter', expected_context['_cookiecutter']),
-        ])
+
+        return OrderedDict(
+            [
+                (C_KEY, OrderedDict([(k, v) for k, v in gen()])),
+                ('_cookiecutter', expected_context['_cookiecutter']),
+            ]
+        )
 
     return {
         'cookie': COOKIE_TEMPLATE_DIR,
@@ -590,9 +599,7 @@ def test_cookiecutter_generates_context_with_expected_values(
     expected_extra_context_passed = None
     if 'interpreters' in EXPECTED_CONTEXT['cookiecutter']:
         expected_extra_context_passed = {
-            'interpreters': EXPECTED_CONTEXT['cookiecutter'][
-                'interpreters'
-            ]
+            'interpreters': EXPECTED_CONTEXT['cookiecutter']['interpreters']
         }
 
     from cookiecutter.generate import generate_context
@@ -634,7 +641,9 @@ def test_cookiecutter_generates_context_with_expected_values(
     # THEN the internal generate_context of coociecutter was called with expected runtime input values
 
     generate_context_mock.assert_called_with(
-        context_file=str(Path(EXPECTED_CONTEXT['cookiecutter']['_template']) / 'cookiecutter.json'),
+        context_file=str(
+            Path(EXPECTED_CONTEXT['cookiecutter']['_template']) / 'cookiecutter.json'
+        ),
         default_context=expected_default_context_passed,
         extra_context=expected_extra_context_passed,
     )
@@ -658,9 +667,7 @@ def test_cookiecutter_generates_context_with_expected_values(
 
     # AND the internal data in jinja context map under 'cookiecutter' key are as expected
     assert len(prod_result[C_KEY]) == len(EXPECTED_CONTEXT[C_KEY])
-    for p1, p2 in zip(
-        prod_result[C_KEY].items(), EXPECTED_CONTEXT[C_KEY].items()
-    ):
+    for p1, p2 in zip(prod_result[C_KEY].items(), EXPECTED_CONTEXT[C_KEY].items()):
         assert p1[0] == p2[0], (
             "All PROD Keys: [\n"
             + '\n'.join(prod_result[C_KEY].keys())
@@ -700,9 +707,7 @@ def test_cookiecutter_generates_context_with_expected_values(
     assert isinstance(prod_result['_cookiecutter'], dict)
 
     # AND the internal data in jinja context map under '_cookiecutter' key are as expected
-    assert len(prod_result['_cookiecutter']) == len(
-        EXPECTED_CONTEXT['_cookiecutter']
-    )
+    assert len(prod_result['_cookiecutter']) == len(EXPECTED_CONTEXT['_cookiecutter'])
     for p1, p2 in zip(
         prod_result['_cookiecutter'].items(),
         EXPECTED_CONTEXT['_cookiecutter'].items(),

--- a/tests/test_docs_gen_feat_compatibillity.py
+++ b/tests/test_docs_gen_feat_compatibillity.py
@@ -104,5 +104,7 @@ def test_gen_parametrized_only_from_user_config_defaults_to_sphinx_builder_n_py3
     assert 'tools' in generated_project_readthedocs_yaml_content['build']
     assert 'python' in generated_project_readthedocs_yaml_content['build']['tools']
 
-    assert generated_project_readthedocs_yaml_content['build']['tools']['python'] == '3.8'
+    assert (
+        generated_project_readthedocs_yaml_content['build']['tools']['python'] == '3.8'
+    )
     # Note: Python RTD 3.8 has been default for some time

--- a/tests/test_docs_id_2_folder_mapping.py
+++ b/tests/test_docs_id_2_folder_mapping.py
@@ -70,7 +70,7 @@ def test_get_docs_gen_internal_config_invalid_folder_name(
 )
 def test_get_docs_gen_internal_config_empty_directory(tmp_path: Path):
     """Test that an empty directory raises an assertion error."""
-    from cookiecutter_python.backend.gen_docs_common import NoDocsTemplateFolderError
+    from cookiecutter_python.backend.gen_docs_common import NoDocsTemplateFolderError  # type: ignore[attr-defined]
 
     with patch(
         "cookiecutter_python.backend.gen_docs_common.PROJ_TEMPLATE_DIR", tmp_path

--- a/tests/test_docs_id_2_folder_mapping.py
+++ b/tests/test_docs_id_2_folder_mapping.py
@@ -70,7 +70,9 @@ def test_get_docs_gen_internal_config_invalid_folder_name(
 )
 def test_get_docs_gen_internal_config_empty_directory(tmp_path: Path):
     """Test that an empty directory raises an assertion error."""
-    from cookiecutter_python.backend.gen_docs_common import NoDocsTemplateFolderError  # type: ignore[attr-defined]
+    from cookiecutter_python.backend.gen_docs_common import (
+        NoDocsTemplateFolderError,  # type: ignore[attr-defined]
+    )
 
     with patch(
         "cookiecutter_python.backend.gen_docs_common.PROJ_TEMPLATE_DIR", tmp_path

--- a/tests/test_docs_id_2_folder_mapping.py
+++ b/tests/test_docs_id_2_folder_mapping.py
@@ -1,0 +1,79 @@
+"""Unit tests for gen_docs_common.py"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cookiecutter_python.backend.gen_docs_common import get_docs_gen_internal_config
+
+
+@pytest.fixture
+def mock_correct_proj_template_dir(tmp_path: Path) -> Path:
+    """Fixture to create a mock project template directory."""
+    docs_mkdocs = tmp_path / "docs-mkdocs"
+    docs_sphinx = tmp_path / "docs-sphinx"
+    docs_newbuilder = tmp_path / "docs-newbuilder"
+    docs_mkdocs.mkdir()
+    docs_sphinx.mkdir()
+    docs_newbuilder.mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def mock_wrong_proj_template_dir(tmp_path: Path) -> Path:
+    """Fixture to create a mock project template directory."""
+    docs_mkdocs = tmp_path / "docs-mkdocs"
+    docs_sphinx = tmp_path / "docs-sphinx"
+    invalid_docs = tmp_path / "docs-invalid-folder"
+    docs_mkdocs.mkdir()
+    docs_sphinx.mkdir()
+    invalid_docs.mkdir()
+    return tmp_path
+
+
+def test_get_docs_gen_internal_config_valid(mock_correct_proj_template_dir: Path):
+    """Test that valid docs folders are correctly mapped."""
+    with patch(
+        "cookiecutter_python.backend.gen_docs_common.PROJ_TEMPLATE_DIR",
+        mock_correct_proj_template_dir,
+    ):
+        result = get_docs_gen_internal_config()
+        assert result == {
+            "mkdocs": "docs-mkdocs",
+            "sphinx": "docs-sphinx",
+            "newbuilder": "docs-newbuilder",
+        }
+
+
+@pytest.mark.xfail(
+    reason="This tests new requirements, but app code is not adjusted yet"
+)
+def test_get_docs_gen_internal_config_invalid_folder_name(
+    mock_wrong_proj_template_dir: Path,
+):
+    """Test that invalid folder names raise a ValueError."""
+    _invalid_folder = mock_wrong_proj_template_dir / "docs-invalid-folder"  # noqa: F841
+    # invalid_folder.rename(mock_proj_template_dir / "docs_invalid")
+    with patch(
+        "cookiecutter_python.backend.gen_docs_common.PROJ_TEMPLATE_DIR",
+        mock_wrong_proj_template_dir,
+    ):
+        with pytest.raises(
+            ValueError, match="Docs Tempate Folder name, does not follow proper pattern"
+        ):
+            get_docs_gen_internal_config()
+
+
+@pytest.mark.xfail(
+    reason="This tests new requirements, but app code is not adjusted yet"
+)
+def test_get_docs_gen_internal_config_empty_directory(tmp_path: Path):
+    """Test that an empty directory raises an assertion error."""
+    from cookiecutter_python.backend.gen_docs_common import NoDocsTemplateFolderError
+
+    with patch(
+        "cookiecutter_python.backend.gen_docs_common.PROJ_TEMPLATE_DIR", tmp_path
+    ):
+        with pytest.raises(NoDocsTemplateFolderError, match="templated_proj_folder"):
+            get_docs_gen_internal_config()

--- a/tests/test_docs_id_2_folder_mapping.py
+++ b/tests/test_docs_id_2_folder_mapping.py
@@ -70,8 +70,8 @@ def test_get_docs_gen_internal_config_invalid_folder_name(
 )
 def test_get_docs_gen_internal_config_empty_directory(tmp_path: Path):
     """Test that an empty directory raises an assertion error."""
-    from cookiecutter_python.backend.gen_docs_common import (
-        NoDocsTemplateFolderError,  # type: ignore[attr-defined]
+    from cookiecutter_python.backend.gen_docs_common import (  # type: ignore[attr-defined]
+        NoDocsTemplateFolderError,
     )
 
     with patch(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -25,10 +25,14 @@ RUNNING_FROM_LOCAL_CHECKOUT: bool = (tests_root.parent / '.github').exists()
 @pytest.mark.parametrize(
     'config_file, expected_interpreters',
     [
-        pytest.param('.github/biskotaki.yaml', ['3.7', '3.8', '3.9', '3.10', '3.11'],             marks=pytest.mark.skipif(
+        pytest.param(
+            '.github/biskotaki.yaml',
+            ['3.7', '3.8', '3.9', '3.10', '3.11'],
+            marks=pytest.mark.skipif(
                 not RUNNING_FROM_LOCAL_CHECKOUT,
                 reason=f"'Running tests from within local checkout is required to test this feature. Current path: {tests_root}'",
-            ),),
+            ),
+        ),
         (None, ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']),
         (
             'tests/data/biskotaki-without-interpreters.yaml',
@@ -126,10 +130,7 @@ def module_file():
         def _get_file_path(*file_path: t.Union[str, Path]):
             l1: t.List[t.Union[str, Path]] = [p, SRC_DIR_NAME, python_module]
 
-            return reduce(
-                lambda i, j: Path(i) / Path(j),
-                l1 + [_ for _ in file_path]
-            )
+            return reduce(lambda i, j: Path(i) / Path(j), l1 + [_ for _ in file_path])
 
         return _get_file_path
 
@@ -139,7 +140,6 @@ def module_file():
 @pytest.fixture(params=[x for x in CLI_RELATED_FILES])
 def cli_related_file_name(request):
     return request.param
-
 
 
 def test_enabling_add_cli_templated_variable(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,5 +1,5 @@
 import typing as t
-
+from pathlib import Path
 import pytest
 
 
@@ -9,15 +9,25 @@ def assert_scaffolded_without_cli(module_file) -> t.Callable[[str], None]:
 
     def assert_project_generated_without_cli(project_dir: str) -> None:
         get_file: t.Callable[[str], str] = module_file(project_dir)
-        assert all(not path.isfile(get_file(file_name)) for file_name in CLI_RELATED_FILES)
+        assert all(
+            not path.isfile(get_file(file_name)) for file_name in CLI_RELATED_FILES
+        )
 
     return assert_project_generated_without_cli
+
+
+# dynamic param 'marks' argument
+tests_root: Path = Path(__file__).parent
+RUNNING_FROM_LOCAL_CHECKOUT: bool = (tests_root.parent / '.github').exists()
 
 
 @pytest.mark.parametrize(
     'config_file, expected_interpreters',
     [
-        ('.github/biskotaki.yaml', ['3.7', '3.8', '3.9', '3.10', '3.11']),
+        pytest.param('.github/biskotaki.yaml', ['3.7', '3.8', '3.9', '3.10', '3.11'],             marks=pytest.mark.skipif(
+                not RUNNING_FROM_LOCAL_CHECKOUT,
+                reason=f"'Running tests from within local checkout is required to test this feature. Current path: {tests_root}'",
+            ),),
         (None, ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']),
         (
             'tests/data/biskotaki-without-interpreters.yaml',
@@ -60,7 +70,9 @@ def test_supported_python_interpreters(
 
 
 @pytest.fixture
-def assert_interpreters_array_in_build_matrix() -> t.Callable[[str, t.Sequence[str]], None]:
+def assert_interpreters_array_in_build_matrix() -> (
+    t.Callable[[str, t.Sequence[str]], None]
+):
     """Test that Job Matrix is generated correctly and stored as Workflow env var.
 
     Test proper generation of github workflow config yaml for lines such as:
@@ -88,11 +100,11 @@ def assert_interpreters_array_in_build_matrix() -> t.Callable[[str, t.Sequence[s
     return _assert_interpreters_array_in_build_matrix
 
 
-CLI_RELATED_FILES = {
+CLI_RELATED_FILES = (
     'cli.py',
     '__main__.py',
-}
-"Files, only expected to be generated for cli type of Projects"
+)
+"""Files, only expected to be generated for cli type of Projects"""
 
 
 @pytest.fixture
@@ -111,7 +123,8 @@ def module_file():
 
         def _get_file_path(*file_path):
             return reduce(
-                lambda i, j: i / j, [p, SRC_DIR_NAME, python_module] + [_ for _ in file_path]
+                lambda i, j: i / j,
+                [p, SRC_DIR_NAME, python_module] + [_ for _ in file_path],
             )
 
         return _get_file_path
@@ -122,6 +135,7 @@ def module_file():
 @pytest.fixture(params=[x for x in CLI_RELATED_FILES])
 def cli_related_file_name(request):
     return request.param
+
 
 
 def test_enabling_add_cli_templated_variable(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,5 +1,6 @@
 import typing as t
 from pathlib import Path
+
 import pytest
 
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -113,18 +113,21 @@ def module_file():
     from os import listdir
     from pathlib import Path
 
-    SRC_DIR_NAME = 'src'
+    SRC_DIR_NAME: str = 'src'
 
     def build_get_file_path(project_dir: str) -> t.Callable[[str], str]:
-        p = Path(project_dir)
+        p: Path = Path(project_dir)
         src_dir_files = listdir(p / SRC_DIR_NAME)
         # sanity check that Generator produces only 1 python module/package
-        [python_module] = src_dir_files
+        assert len(src_dir_files) == 1
+        python_module: str = src_dir_files[0]
 
-        def _get_file_path(*file_path):
+        def _get_file_path(*file_path: t.Union[str, Path]):
+            l1: t.List[t.Union[str, Path]] = [p, SRC_DIR_NAME, python_module]
+
             return reduce(
-                lambda i, j: i / j,
-                [p, SRC_DIR_NAME, python_module] + [_ for _ in file_path],
+                lambda i, j: Path(i) / Path(j),
+                l1 + [_ for _ in file_path]
             )
 
         return _get_file_path

--- a/tests/test_gold_standard.py
+++ b/tests/test_gold_standard.py
@@ -123,10 +123,9 @@ def test_gs_matches_runtime(gen_gs_project, test_root):
     # if 'cookie-py.log' file found show warning
     if Path('cookie-py.log') in snap_relative_paths_set:
         import logging
+
         logger = logging.getLogger(__name__)
-        logger.warning(
-            "cookie-py.log file found in snapshot"
-        )
+        logger.warning("cookie-py.log file found in snapshot")
 
     # GIVEN we find the Runtime files (paths to dirs and files), using glob
     runtime_relative_paths_set = set(

--- a/tests/test_gold_standard.py
+++ b/tests/test_gold_standard.py
@@ -120,6 +120,14 @@ def test_gs_matches_runtime(gen_gs_project, test_root):
         [x.relative_to(snapshot_dir) for x in snapshot_dir.glob('**/*')]
     )
 
+    # if 'cookie-py.log' file found show warning
+    if Path('cookie-py.log') in snap_relative_paths_set:
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.warning(
+            "cookie-py.log file found in snapshot"
+        )
+
     # GIVEN we find the Runtime files (paths to dirs and files), using glob
     runtime_relative_paths_set = set(
         [x.relative_to(runtime_gs) for x in runtime_gs.glob('**/*')]

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -10,7 +10,9 @@ def test_simple_invocation(run_subprocess):
         '--help',
     )
     assert result.exit_code == 0
-    assert re.match(r'Usage: generate\-python \[OPTIONS\]', result.stdout.split('\n')[0])
+    assert re.match(
+        r'Usage: generate\-python \[OPTIONS\]', result.stdout.split('\n')[0]
+    )
     assert result.stderr == ''
 
 

--- a/tests/test_post_hook.py
+++ b/tests/test_post_hook.py
@@ -154,7 +154,9 @@ def create_request_from_emulated_project(request_factory):
         # theoritically, it should suffice for us to create 'emulated' files, as:
         # Excluding the Docs Builder defined in the Request, create file for all
         # builders in the map
-        requested_docs_builder_id: str = emulated_post_gen_request.docs_website['builder']
+        requested_docs_builder_id: str = emulated_post_gen_request.docs_website[
+            'builder'
+        ]
 
         assert requested_docs_builder_id == 'sphinx'
         assert builder_id_2_extra_files_map == {
@@ -204,7 +206,9 @@ def get_post_gen_main(get_object):
         add_cli: bool,
         project_dir: Path,
         extra_files: t.Optional[t.List[t.Union[str, t.Tuple[str, ...]]]] = None,
-        extra_non_empty_files: t.Optional[t.List[t.Union[str, t.Tuple[str, ...]]]] = None,
+        extra_non_empty_files: t.Optional[
+            t.List[t.Union[str, t.Tuple[str, ...]]]
+        ] = None,
         **kwargs,
     ):
         """"""
@@ -304,7 +308,9 @@ def test_main(
     from pathlib import Path
 
     # GIVEN a temporary directory, for the emulated generated project
-    tmp_target_gen_dir = tmpdir.mkdir('cookiecutter_python.unit-tests.proj-targetr-gen-dir')
+    tmp_target_gen_dir = tmpdir.mkdir(
+        'cookiecutter_python.unit-tests.proj-targetr-gen-dir'
+    )
 
     post_hook_main = get_post_gen_main(
         create_request_from_emulated_project,
@@ -406,7 +412,9 @@ def test_stable_cicd_was_selected_and_worked(
     from pathlib import Path
 
     # GIVEN a temporary directory, for the emulated generated project
-    tmp_target_gen_dir = tmpdir.mkdir('cookiecutter_python.unit-tests.proj-targetr-gen-dir')
+    tmp_target_gen_dir = tmpdir.mkdir(
+        'cookiecutter_python.unit-tests.proj-targetr-gen-dir'
+    )
 
     post_hook_main = get_post_gen_main(
         create_request_from_emulated_project,
@@ -426,8 +434,12 @@ def test_stable_cicd_was_selected_and_worked(
 
     # AND the files for 'experimental' cicd optoin are missing
     assert not (Path(tmp_target_gen_dir) / '.github/workflows/cicd.yml').exists()
-    assert not (Path(tmp_target_gen_dir) / '.github/workflows/codecov-upload.yml').exists()
-    assert not (Path(tmp_target_gen_dir) / '.github/workflows/signal-deploy.yml').exists()
+    assert not (
+        Path(tmp_target_gen_dir) / '.github/workflows/codecov-upload.yml'
+    ).exists()
+    assert not (
+        Path(tmp_target_gen_dir) / '.github/workflows/signal-deploy.yml'
+    ).exists()
 
 
 def test_experimental_cicd_was_selected_and_worked(
@@ -436,7 +448,9 @@ def test_experimental_cicd_was_selected_and_worked(
     from pathlib import Path
 
     # GIVEN a temporary directory, for the emulated generated project
-    tmp_target_gen_dir = tmpdir.mkdir('cookiecutter_python.unit-tests.proj-targetr-gen-dir')
+    tmp_target_gen_dir = tmpdir.mkdir(
+        'cookiecutter_python.unit-tests.proj-targetr-gen-dir'
+    )
 
     post_hook_main = get_post_gen_main(
         create_request_from_emulated_project,

--- a/tests/test_prehook.py
+++ b/tests/test_prehook.py
@@ -101,7 +101,9 @@ def get_main_with_mocked_template(get_object, request_factory):
 def test_main_with_invalid_interpreters(get_main_with_mocked_template, request_factory):
     result = get_main_with_mocked_template(
         overrides={
-            "get_request": lambda: lambda: request_factory.pre(interpreters=['3.5', '3.10'])
+            "get_request": lambda: lambda: request_factory.pre(
+                interpreters=['3.5', '3.10']
+            )
         }
     )()
     assert result == 1  # exit code of 1 indicates failed execution
@@ -109,7 +111,9 @@ def test_main_with_invalid_interpreters(get_main_with_mocked_template, request_f
 
 def test_main_with_invalid_module_name(get_main_with_mocked_template, request_factory):
     result = get_main_with_mocked_template(
-        overrides={"get_request": lambda: lambda: request_factory.pre(module_name="121212")}
+        overrides={
+            "get_request": lambda: lambda: request_factory.pre(module_name="121212")
+        }
     )()
     assert result == 1  # exit code of 1 indicates failed execution
 
@@ -130,6 +134,8 @@ def test_main_with_found_pre_existing_pypi_package(
     get_main_with_mocked_template, request_factory
 ):
     result = get_main_with_mocked_template(
-        overrides={"get_request": lambda: lambda: request_factory.pre(module_name="so_magic")}
+        overrides={
+            "get_request": lambda: lambda: request_factory.pre(module_name="so_magic")
+        }
     )()
     assert result == 0  # exit code of 1 indicates failed execution

--- a/tests/test_running_test_suite.py
+++ b/tests/test_running_test_suite.py
@@ -23,14 +23,20 @@ def environment():
         if sys.platform == 'win32':  # ie we are on a Windows OS
             return dict(
                 environment_variables,
-                **{'LC_ALL': 'C.UTF-8', 'LANG': 'C.UTF-8', 'PYTHONHASHSEED': '2577074909'},
+                **{
+                    'LC_ALL': 'C.UTF-8',
+                    'LANG': 'C.UTF-8',
+                    'PYTHONHASHSEED': '2577074909',
+                },
             )
         raise RuntimeError(f'Unexpected System Found: {sys.platform}')
 
     return get_environment_variables
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason="not working out-of-the-box for Windows")
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason="not working out-of-the-box for Windows"
+)
 def test_running_pytest(environment, run_subprocess, project_dir):
     result = run_subprocess(
         sys.executable,

--- a/tests/test_sanitization_component.py
+++ b/tests/test_sanitization_component.py
@@ -16,7 +16,9 @@ def test_registering_multiple_exceptions_under_the_same_type_allows_catching_mul
 
     # Backend Code that declares and registers a new Sanitizer
     @Sanitize.register_sanitizer(SANITIZE_TASK_TYPE)
-    def verify_input_string_not_empty_and_only_lowercase_latin_chars(string: str) -> None:
+    def verify_input_string_not_empty_and_only_lowercase_latin_chars(
+        string: str,
+    ) -> None:
 
         if len(string) < 1:
             raise StringWithNoLengthError("String With No Length Error")

--- a/tests/test_sanitization_component.py
+++ b/tests/test_sanitization_component.py
@@ -43,7 +43,7 @@ def test_registering_multiple_exceptions_under_the_same_type_allows_catching_mul
     from cookiecutter_python.backend import sanitize
 
     assert SANITIZE_TASK_TYPE in sanitize.sanitizers_map
-    assert sanitize.sanitizers_map[SANITIZE_TASK_TYPE]
+    assert sanitize.sanitizers_map[SANITIZE_TASK_TYPE]  # type:ignore[truthy-function]
 
     # SANITY Production Sanitizers automatically loaded!
     PRODUCTION_SANITIZERS = {

--- a/tests/test_snapshot_workflow_yaml.py
+++ b/tests/test_snapshot_workflow_yaml.py
@@ -38,11 +38,9 @@ def test_referenced_job_output_vars_correspond_to_existing_jobs(
     # GIVEN the EXPECTED paths to the generated Github Workflows per CICD Option
     from cookiecutter_python.hooks.post_gen_project import CICD_DELETE
 
-    d: t.Dict[str, t.List[t.Tuple[str, ...]]] = CICD_DELETE
-
     all_rendered_yaml_workflows: t.Set[t.Tuple[str, ...]] = {
         tuple_of_strings
-        for list_of_tuples in d.values()
+        for list_of_tuples in CICD_DELETE.values()
         for tuple_of_strings in list_of_tuples
     }
 

--- a/tests/test_snapshot_workflow_yaml.py
+++ b/tests/test_snapshot_workflow_yaml.py
@@ -11,7 +11,8 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    'snapshot', ["biskotaki-gold-standard", "biskotaki-no-input", "biskotaki-interactive"]
+    'snapshot',
+    ["biskotaki-gold-standard", "biskotaki-no-input", "biskotaki-interactive"],
 )
 def test_referenced_job_output_vars_correspond_to_existing_jobs(
     # GIVEN a Snapshot from calling the Generator
@@ -77,7 +78,9 @@ def test_referenced_job_output_vars_correspond_to_existing_jobs(
         'biskotaki-interactive': 'experimental',
     }
     # GIVEN we identify the Snapshot's project cicd option used at generation time
-    snapshot_cicd_value: CICDDesignOption = snapshot_name_2_cicd_option_value[SNAPSHOT_NAME]
+    snapshot_cicd_value: CICDDesignOption = snapshot_name_2_cicd_option_value[
+        SNAPSHOT_NAME
+    ]
 
     # WHEN we iterate over the expected generated workflows for this Snapshot
     import yaml
@@ -90,7 +93,8 @@ def test_referenced_job_output_vars_correspond_to_existing_jobs(
             # except poyo.exceptions.PoyoException as error:
             except yaml.YAMLError as error:
                 raise RuntimeError(
-                    'Unable to parse YAML file {}. Error: {}' ''.format(yaml_workflow, error)
+                    'Unable to parse YAML file {}. Error: {}'
+                    ''.format(yaml_workflow, error)
                 ) from error
             # THEN we check the yaml_dict that all jobs that reference variables from other jobs also depend on those jobs
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,14 +46,13 @@ setenv =
     COVERAGE_FILE = {toxworkdir}{/}.coverage.{envname}
     TEST_STATUS_DIR = {envtmpdir}
     PYPY3323BUG = 1
-    black,lint,isort,ruff: LINT_ARGS = "tests src{/}cookiecutter_python{/}backend src{/}cookiecutter_python{/}handle scripts"
 
     # For Windows: account for inability to do post Gen delete of log file in
     # Gen Proj Dir, due to Permission Error, when running on windows:
     # other process is using the file, so removing is denied, at Generator runtime
 
     # log deletion post hook fails on windows, due to permission error! (other process is using the file, so removing is denied)
-    # windows spawn multiple processes, so log deletion is not possible, even when running 1 Single Uni Tests
+    # windows spawn multiple processes, so log deletion is not possible, even when running 1 Single Unit Test
     BUG_LOG_DEL_WIN = permission_error
 
     # Fallback File name for storing output of for all poetry export operations
@@ -66,6 +65,26 @@ commands =
       --cov-report=html:{envdir}/htmlcov --cov-context=test \
       --cov-report=xml:{toxworkdir}/coverage.{envname}.xml \
       {posargs:-n auto {toxinidir}{/}tests}
+
+### Quick Testing locally ###
+[testenv:dev]
+description = Install in 'edit' mode & Test
+basepython = {env:TOXPYTHON:python3}
+# deps = tox == 3.27.1  # required when enabling --run-integration pytest flag
+usedevelop = true
+commands = pytest -ra {posargs:-n auto} {toxinidir}{/}tests
+
+[testenv:dev-cov]
+description = Using `python3` in PATH: Install in 'edit' mode, Test & measure Coverage
+basepython = {env:TOXPYTHON:python3}
+deps = tox == 3.27.1  # required when enabling --run-integration pytest flag
+usedevelop = true
+commands =
+    pytest -ra --cov --cov-report=term-missing \
+      --cov-report=html:{envdir}/htmlcov --cov-context=test \
+      --cov-report=xml:{toxworkdir}/coverage.{envname}.xml \
+      {posargs:-n auto} {toxinidir}{/}tests
+
 
 # PATH
 [testenv:{py312, py311, py310, py39, py38, py37, py36, pypy3}-path{, -linux, -macos, -windows}]
@@ -142,24 +161,6 @@ commands_pre = {[wheel_env]commands_pre}
 description = Install in 'edit' mode & Test
 usedevelop = true
 
-# Designed for local developement
-[testenv:dev]
-description = Using `python3` in PATH: Install in 'edit' mode & Test
-basepython = {env:TOXPYTHON:python3}
-deps = tox == 3.27.1  # required when enabling --run-integration pytest flag
-usedevelop = true
-commands = pytest -ra {posargs:-n auto} {toxinidir}{/}tests
-
-[testenv:dev-cov]
-description = Using `python3` in PATH: Install in 'edit' mode, Test & measure Coverage
-basepython = {env:TOXPYTHON:python3}
-deps = tox == 3.27.1  # required when enabling --run-integration pytest flag
-usedevelop = true
-commands =
-    pytest -ra --cov --cov-report=term-missing \
-      --cov-report=html:{envdir}/htmlcov --cov-context=test \
-      --cov-report=xml:{toxworkdir}/coverage.{envname}.xml \
-      {posargs:-n auto} {toxinidir}{/}tests
 
 [testenv:coverage]
 description = combine coverage from test environments
@@ -180,7 +181,6 @@ commands =
     coverage xml -o {toxworkdir}/coverage.xml -i
     coverage html -d {toxworkdir}/htmlcov -i
 depends = {py311, py310, py39, py38, py37, py36}{, -path, -sdist, -wheel, -dev}
-
 
 
 
@@ -407,6 +407,8 @@ setenv =
     ISORT_EXCLUDE = '{env:TESTS_DIR_NAME}{/}{env:TEST_DATA_DIR_NAME}{/}{env:TEST_SNAPSHOTS_DIR_NAME}'
     BLACK_EXCLUDE = '{env:TESTS_DIR_NAME}/{env:TEST_DATA_DIR_NAME}/{env:TEST_SNAPSHOTS_DIR_NAME}'
     # Note: we use forward slashes (/), because Black resolves paths under the hood
+
+    LINT_ARGS = "tests src{/}cookiecutter_python{/}backend src{/}cookiecutter_python{/}handle scripts"
 
 [testenv:lint]
 description = test if code conforms with our styles

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,1651 @@
+version = 1
+revision = 1
+requires-python = ">=3.8, <3.13"
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+    "python_full_version < '3.9'",
+]
+
+[[package]]
+name = "alabaster"
+version = "0.7.13"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/71/a8ee96d1fd95ca04a0d2e2d9c4081dac4c2d2b12f7ddb899c8cb9bfd1532/alabaster-0.7.13.tar.gz", hash = "sha256:a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2", size = 11454 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/88/c7083fc61120ab661c5d0b82cb77079fc1429d3f913a456c1c82cf4658f7/alabaster-0.7.13-py3-none-any.whl", hash = "sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3", size = 13857 },
+]
+
+[[package]]
+name = "alabaster"
+version = "0.7.16"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/3e/13dd8e5ed9094e734ac430b5d0eb4f2bb001708a8b7856cbf8e084e001ba/alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65", size = 23776 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92", size = 13511 },
+]
+
+[[package]]
+name = "arrow"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "types-python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/00/0f6e8fcdb23ea632c866620cc872729ff43ed91d284c866b515c6342b173/arrow-1.3.0.tar.gz", hash = "sha256:d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85", size = 131960 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/ed/e97229a566617f2ae958a6b13e7cc0f585470eac730a73e9e82c32a3cdd2/arrow-1.3.0-py3-none-any.whl", hash = "sha256:c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80", size = 66419 },
+]
+
+[[package]]
+name = "attrs"
+version = "21.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/77/ebb15fc26d0f815839ecd897b919ed6d85c050feeb83e100e020df9153d2/attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd", size = 201839 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/be/7abce643bfdf8ca01c48afa2ddf8308c2308b0c3b239a44e57d020afa0ef/attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4", size = 60567 },
+]
+
+[[package]]
+name = "babel"
+version = "2.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytz", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537 },
+]
+
+[[package]]
+name = "binaryornot"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/fe/7ebfec74d49f97fc55cd38240c7a7d08134002b1e14be8c3897c0dd5e49b/binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061", size = 371054 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/7e/f7b6f453e6481d1e233540262ccbfcf89adcd43606f44a028d7f5fae5eb2/binaryornot-0.4.4-py2.py3-none-any.whl", hash = "sha256:b8b71173c917bddcd2c16070412e369c3ed7f0528926f70cac18a6c97fd563e4", size = 9006 },
+]
+
+[[package]]
+name = "build"
+version = "1.2.2.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "importlib-metadata", version = "8.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.10.2'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/46/aeab111f8e06793e4f0e421fcad593d547fb8313b50990f31681ee2fb1ad/build-1.2.2.post1.tar.gz", hash = "sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7", size = 46701 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/c2/80633736cd183ee4a62107413def345f7e6e3c01563dbca1417363cf957e/build-1.2.2.post1-py3-none-any.whl", hash = "sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5", size = 22950 },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.1.31"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393 },
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385 },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3", size = 123188 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/58/5580c1716040bc89206c77d8f74418caf82ce519aae06450393ca73475d1/charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de", size = 198013 },
+    { url = "https://files.pythonhosted.org/packages/d0/11/00341177ae71c6f5159a08168bcb98c6e6d196d372c94511f9f6c9afe0c6/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176", size = 141285 },
+    { url = "https://files.pythonhosted.org/packages/01/09/11d684ea5819e5a8f5100fb0b38cf8d02b514746607934134d31233e02c8/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e218488cd232553829be0664c2292d3af2eeeb94b32bea483cf79ac6a694e037", size = 151449 },
+    { url = "https://files.pythonhosted.org/packages/08/06/9f5a12939db324d905dc1f70591ae7d7898d030d7662f0d426e2286f68c9/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80ed5e856eb7f30115aaf94e4a08114ccc8813e6ed1b5efa74f9f82e8509858f", size = 143892 },
+    { url = "https://files.pythonhosted.org/packages/93/62/5e89cdfe04584cb7f4d36003ffa2936681b03ecc0754f8e969c2becb7e24/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b010a7a4fd316c3c484d482922d13044979e78d1861f0e0650423144c616a46a", size = 146123 },
+    { url = "https://files.pythonhosted.org/packages/a9/ac/ab729a15c516da2ab70a05f8722ecfccc3f04ed7a18e45c75bbbaa347d61/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4532bff1b8421fd0a320463030c7520f56a79c9024a4e88f01c537316019005a", size = 147943 },
+    { url = "https://files.pythonhosted.org/packages/03/d2/3f392f23f042615689456e9a274640c1d2e5dd1d52de36ab8f7955f8f050/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d973f03c0cb71c5ed99037b870f2be986c3c05e63622c017ea9816881d2dd247", size = 142063 },
+    { url = "https://files.pythonhosted.org/packages/f2/e3/e20aae5e1039a2cd9b08d9205f52142329f887f8cf70da3650326670bddf/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3a3bd0dcd373514dcec91c411ddb9632c0d7d92aed7093b8c3bbb6d69ca74408", size = 150578 },
+    { url = "https://files.pythonhosted.org/packages/8d/af/779ad72a4da0aed925e1139d458adc486e61076d7ecdcc09e610ea8678db/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:d9c3cdf5390dcd29aa8056d13e8e99526cda0305acc038b96b30352aff5ff2bb", size = 153629 },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/7aa450b278e7aa92cf7732140bfd8be21f5f29d5bf334ae987c945276639/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2bdfe3ac2e1bbe5b59a1a63721eb3b95fc9b6817ae4a46debbb4e11f6232428d", size = 150778 },
+    { url = "https://files.pythonhosted.org/packages/39/f4/d9f4f712d0951dcbfd42920d3db81b00dd23b6ab520419626f4023334056/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:eab677309cdb30d047996b36d34caeda1dc91149e4fdca0b1a039b3f79d9a807", size = 146453 },
+    { url = "https://files.pythonhosted.org/packages/49/2b/999d0314e4ee0cff3cb83e6bc9aeddd397eeed693edb4facb901eb8fbb69/charset_normalizer-3.4.1-cp310-cp310-win32.whl", hash = "sha256:c0429126cf75e16c4f0ad00ee0eae4242dc652290f940152ca8c75c3a4b6ee8f", size = 95479 },
+    { url = "https://files.pythonhosted.org/packages/2d/ce/3cbed41cff67e455a386fb5e5dd8906cdda2ed92fbc6297921f2e4419309/charset_normalizer-3.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:9f0b8b1c6d84c8034a44893aba5e767bf9c7a211e313a9605d9c617d7083829f", size = 102790 },
+    { url = "https://files.pythonhosted.org/packages/72/80/41ef5d5a7935d2d3a773e3eaebf0a9350542f2cab4eac59a7a4741fbbbbe/charset_normalizer-3.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125", size = 194995 },
+    { url = "https://files.pythonhosted.org/packages/7a/28/0b9fefa7b8b080ec492110af6d88aa3dea91c464b17d53474b6e9ba5d2c5/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1", size = 139471 },
+    { url = "https://files.pythonhosted.org/packages/71/64/d24ab1a997efb06402e3fc07317e94da358e2585165930d9d59ad45fcae2/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f08ff5e948271dc7e18a35641d2f11a4cd8dfd5634f55228b691e62b37125eb3", size = 149831 },
+    { url = "https://files.pythonhosted.org/packages/37/ed/be39e5258e198655240db5e19e0b11379163ad7070962d6b0c87ed2c4d39/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:234ac59ea147c59ee4da87a0c0f098e9c8d169f4dc2a159ef720f1a61bbe27cd", size = 142335 },
+    { url = "https://files.pythonhosted.org/packages/88/83/489e9504711fa05d8dde1574996408026bdbdbd938f23be67deebb5eca92/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00", size = 143862 },
+    { url = "https://files.pythonhosted.org/packages/c6/c7/32da20821cf387b759ad24627a9aca289d2822de929b8a41b6241767b461/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eea6ee1db730b3483adf394ea72f808b6e18cf3cb6454b4d86e04fa8c4327a12", size = 145673 },
+    { url = "https://files.pythonhosted.org/packages/68/85/f4288e96039abdd5aeb5c546fa20a37b50da71b5cf01e75e87f16cd43304/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c96836c97b1238e9c9e3fe90844c947d5afbf4f4c92762679acfe19927d81d77", size = 140211 },
+    { url = "https://files.pythonhosted.org/packages/28/a3/a42e70d03cbdabc18997baf4f0227c73591a08041c149e710045c281f97b/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4d86f7aff21ee58f26dcf5ae81a9addbd914115cdebcbb2217e4f0ed8982e146", size = 148039 },
+    { url = "https://files.pythonhosted.org/packages/85/e4/65699e8ab3014ecbe6f5c71d1a55d810fb716bbfd74f6283d5c2aa87febf/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:09b5e6733cbd160dcc09589227187e242a30a49ca5cefa5a7edd3f9d19ed53fd", size = 151939 },
+    { url = "https://files.pythonhosted.org/packages/b1/82/8e9fe624cc5374193de6860aba3ea8070f584c8565ee77c168ec13274bd2/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5777ee0881f9499ed0f71cc82cf873d9a0ca8af166dfa0af8ec4e675b7df48e6", size = 149075 },
+    { url = "https://files.pythonhosted.org/packages/3d/7b/82865ba54c765560c8433f65e8acb9217cb839a9e32b42af4aa8e945870f/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:237bdbe6159cff53b4f24f397d43c6336c6b0b42affbe857970cefbb620911c8", size = 144340 },
+    { url = "https://files.pythonhosted.org/packages/b5/b6/9674a4b7d4d99a0d2df9b215da766ee682718f88055751e1e5e753c82db0/charset_normalizer-3.4.1-cp311-cp311-win32.whl", hash = "sha256:8417cb1f36cc0bc7eaba8ccb0e04d55f0ee52df06df3ad55259b9a323555fc8b", size = 95205 },
+    { url = "https://files.pythonhosted.org/packages/1e/ab/45b180e175de4402dcf7547e4fb617283bae54ce35c27930a6f35b6bef15/charset_normalizer-3.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:d7f50a1f8c450f3925cb367d011448c39239bb3eb4117c36a6d354794de4ce76", size = 102441 },
+    { url = "https://files.pythonhosted.org/packages/0a/9a/dd1e1cdceb841925b7798369a09279bd1cf183cef0f9ddf15a3a6502ee45/charset_normalizer-3.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545", size = 196105 },
+    { url = "https://files.pythonhosted.org/packages/d3/8c/90bfabf8c4809ecb648f39794cf2a84ff2e7d2a6cf159fe68d9a26160467/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7", size = 140404 },
+    { url = "https://files.pythonhosted.org/packages/ad/8f/e410d57c721945ea3b4f1a04b74f70ce8fa800d393d72899f0a40526401f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757", size = 150423 },
+    { url = "https://files.pythonhosted.org/packages/f0/b8/e6825e25deb691ff98cf5c9072ee0605dc2acfca98af70c2d1b1bc75190d/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa", size = 143184 },
+    { url = "https://files.pythonhosted.org/packages/3e/a2/513f6cbe752421f16d969e32f3583762bfd583848b763913ddab8d9bfd4f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d", size = 145268 },
+    { url = "https://files.pythonhosted.org/packages/74/94/8a5277664f27c3c438546f3eb53b33f5b19568eb7424736bdc440a88a31f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616", size = 147601 },
+    { url = "https://files.pythonhosted.org/packages/7c/5f/6d352c51ee763623a98e31194823518e09bfa48be2a7e8383cf691bbb3d0/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b", size = 141098 },
+    { url = "https://files.pythonhosted.org/packages/78/d4/f5704cb629ba5ab16d1d3d741396aec6dc3ca2b67757c45b0599bb010478/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d", size = 149520 },
+    { url = "https://files.pythonhosted.org/packages/c5/96/64120b1d02b81785f222b976c0fb79a35875457fa9bb40827678e54d1bc8/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a", size = 152852 },
+    { url = "https://files.pythonhosted.org/packages/84/c9/98e3732278a99f47d487fd3468bc60b882920cef29d1fa6ca460a1fdf4e6/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9", size = 150488 },
+    { url = "https://files.pythonhosted.org/packages/13/0e/9c8d4cb99c98c1007cc11eda969ebfe837bbbd0acdb4736d228ccaabcd22/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1", size = 146192 },
+    { url = "https://files.pythonhosted.org/packages/b2/21/2b6b5b860781a0b49427309cb8670785aa543fb2178de875b87b9cc97746/charset_normalizer-3.4.1-cp312-cp312-win32.whl", hash = "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35", size = 95550 },
+    { url = "https://files.pythonhosted.org/packages/21/5b/1b390b03b1d16c7e382b561c5329f83cc06623916aab983e8ab9239c7d5c/charset_normalizer-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f", size = 102785 },
+    { url = "https://files.pythonhosted.org/packages/10/bd/6517ea94f2672e801011d50b5d06be2a0deaf566aea27bcdcd47e5195357/charset_normalizer-3.4.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ecddf25bee22fe4fe3737a399d0d177d72bc22be6913acfab364b40bce1ba83c", size = 195653 },
+    { url = "https://files.pythonhosted.org/packages/e5/0d/815a2ba3f283b4eeaa5ece57acade365c5b4135f65a807a083c818716582/charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c60ca7339acd497a55b0ea5d506b2a2612afb2826560416f6894e8b5770d4a9", size = 140701 },
+    { url = "https://files.pythonhosted.org/packages/aa/17/c94be7ee0d142687e047fe1de72060f6d6837f40eedc26e87e6e124a3fc6/charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b7b2d86dd06bfc2ade3312a83a5c364c7ec2e3498f8734282c6c3d4b07b346b8", size = 150495 },
+    { url = "https://files.pythonhosted.org/packages/f7/33/557ac796c47165fc141e4fb71d7b0310f67e05cb420756f3a82e0a0068e0/charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd78cfcda14a1ef52584dbb008f7ac81c1328c0f58184bf9a84c49c605002da6", size = 142946 },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/38ef4ae41e9248d63fc4998d933cae22473b1b2ac4122cf908d0f5eb32aa/charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e27f48bcd0957c6d4cb9d6fa6b61d192d0b13d5ef563e5f2ae35feafc0d179c", size = 144737 },
+    { url = "https://files.pythonhosted.org/packages/43/01/754cdb29dd0560f58290aaaa284d43eea343ad0512e6ad3b8b5c11f08592/charset_normalizer-3.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01ad647cdd609225c5350561d084b42ddf732f4eeefe6e678765636791e78b9a", size = 147471 },
+    { url = "https://files.pythonhosted.org/packages/ba/cd/861883ba5160c7a9bd242c30b2c71074cda2aefcc0addc91118e0d4e0765/charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:619a609aa74ae43d90ed2e89bdd784765de0a25ca761b93e196d938b8fd1dbbd", size = 140801 },
+    { url = "https://files.pythonhosted.org/packages/6f/7f/0c0dad447819e90b93f8ed238cc8f11b91353c23c19e70fa80483a155bed/charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:89149166622f4db9b4b6a449256291dc87a99ee53151c74cbd82a53c8c2f6ccd", size = 149312 },
+    { url = "https://files.pythonhosted.org/packages/8e/09/9f8abcc6fff60fb727268b63c376c8c79cc37b833c2dfe1f535dfb59523b/charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:7709f51f5f7c853f0fb938bcd3bc59cdfdc5203635ffd18bf354f6967ea0f824", size = 152347 },
+    { url = "https://files.pythonhosted.org/packages/be/e5/3f363dad2e24378f88ccf63ecc39e817c29f32e308ef21a7a6d9c1201165/charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:345b0426edd4e18138d6528aed636de7a9ed169b4aaf9d61a8c19e39d26838ca", size = 149888 },
+    { url = "https://files.pythonhosted.org/packages/e4/10/a78c0e91f487b4ad0ef7480ac765e15b774f83de2597f1b6ef0eaf7a2f99/charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:0907f11d019260cdc3f94fbdb23ff9125f6b5d1039b76003b5b0ac9d6a6c9d5b", size = 145169 },
+    { url = "https://files.pythonhosted.org/packages/d3/81/396e7d7f5d7420da8273c91175d2e9a3f569288e3611d521685e4b9ac9cc/charset_normalizer-3.4.1-cp38-cp38-win32.whl", hash = "sha256:ea0d8d539afa5eb2728aa1932a988a9a7af94f18582ffae4bc10b3fbdad0626e", size = 95094 },
+    { url = "https://files.pythonhosted.org/packages/40/bb/20affbbd9ea29c71ea123769dc568a6d42052ff5089c5fe23e21e21084a6/charset_normalizer-3.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:329ce159e82018d646c7ac45b01a430369d526569ec08516081727a20e9e4af4", size = 102139 },
+    { url = "https://files.pythonhosted.org/packages/7f/c0/b913f8f02836ed9ab32ea643c6fe4d3325c3d8627cf6e78098671cafff86/charset_normalizer-3.4.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b97e690a2118911e39b4042088092771b4ae3fc3aa86518f84b8cf6888dbdb41", size = 197867 },
+    { url = "https://files.pythonhosted.org/packages/0f/6c/2bee440303d705b6fb1e2ec789543edec83d32d258299b16eed28aad48e0/charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78baa6d91634dfb69ec52a463534bc0df05dbd546209b79a3880a34487f4b84f", size = 141385 },
+    { url = "https://files.pythonhosted.org/packages/3d/04/cb42585f07f6f9fd3219ffb6f37d5a39b4fd2db2355b23683060029c35f7/charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1a2bc9f351a75ef49d664206d51f8e5ede9da246602dc2d2726837620ea034b2", size = 151367 },
+    { url = "https://files.pythonhosted.org/packages/54/54/2412a5b093acb17f0222de007cc129ec0e0df198b5ad2ce5699355269dfe/charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75832c08354f595c760a804588b9357d34ec00ba1c940c15e31e96d902093770", size = 143928 },
+    { url = "https://files.pythonhosted.org/packages/5a/6d/e2773862b043dcf8a221342954f375392bb2ce6487bcd9f2c1b34e1d6781/charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0af291f4fe114be0280cdd29d533696a77b5b49cfde5467176ecab32353395c4", size = 146203 },
+    { url = "https://files.pythonhosted.org/packages/b9/f8/ca440ef60d8f8916022859885f231abb07ada3c347c03d63f283bec32ef5/charset_normalizer-3.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0167ddc8ab6508fe81860a57dd472b2ef4060e8d378f0cc555707126830f2537", size = 148082 },
+    { url = "https://files.pythonhosted.org/packages/04/d2/42fd330901aaa4b805a1097856c2edf5095e260a597f65def493f4b8c833/charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2a75d49014d118e4198bcee5ee0a6f25856b29b12dbf7cd012791f8a6cc5c496", size = 142053 },
+    { url = "https://files.pythonhosted.org/packages/9e/af/3a97a4fa3c53586f1910dadfc916e9c4f35eeada36de4108f5096cb7215f/charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363e2f92b0f0174b2f8238240a1a30142e3db7b957a5dd5689b0e75fb717cc78", size = 150625 },
+    { url = "https://files.pythonhosted.org/packages/26/ae/23d6041322a3556e4da139663d02fb1b3c59a23ab2e2b56432bd2ad63ded/charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:ab36c8eb7e454e34e60eb55ca5d241a5d18b2c6244f6827a30e451c42410b5f7", size = 153549 },
+    { url = "https://files.pythonhosted.org/packages/94/22/b8f2081c6a77cb20d97e57e0b385b481887aa08019d2459dc2858ed64871/charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:4c0907b1928a36d5a998d72d64d8eaa7244989f7aaaf947500d3a800c83a3fd6", size = 150945 },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/c5ec5092747f801b8b093cdf5610e732b809d6cb11f4c51e35fc28d1d389/charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:04432ad9479fa40ec0f387795ddad4437a2b50417c69fa275e212933519ff294", size = 146595 },
+    { url = "https://files.pythonhosted.org/packages/0c/5a/0b59704c38470df6768aa154cc87b1ac7c9bb687990a1559dc8765e8627e/charset_normalizer-3.4.1-cp39-cp39-win32.whl", hash = "sha256:3bed14e9c89dcb10e8f3a29f9ccac4955aebe93c71ae803af79265c9ca5644c5", size = 95453 },
+    { url = "https://files.pythonhosted.org/packages/85/2d/a9790237cb4d01a6d57afadc8573c8b73c609ade20b80f4cda30802009ee/charset_normalizer-3.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:49402233c892a461407c512a19435d1ce275543138294f7ef013f0b63d5d3765", size = 102811 },
+    { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767 },
+]
+
+[[package]]
+name = "click"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "cookiecutter"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+    { name = "binaryornot" },
+    { name = "click" },
+    { name = "jinja2" },
+    { name = "python-slugify" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/17/9f2cd228eb949a91915acd38d3eecdc9d8893dde353b603f0db7e9f6be55/cookiecutter-2.6.0.tar.gz", hash = "sha256:db21f8169ea4f4fdc2408d48ca44859349de2647fbe494a9d6c3edfc0542c21c", size = 158767 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/d9/0137658a353168ffa9d0fc14b812d3834772040858ddd1cb6eeaf09f7a44/cookiecutter-2.6.0-py3-none-any.whl", hash = "sha256:a54a8e37995e4ed963b3e82831072d1ad4b005af736bb17b99c2cbd9d41b6e2d", size = 39177 },
+]
+
+[[package]]
+name = "cookiecutter-python"
+version = "2.5.0"
+source = { editable = "." }
+dependencies = [
+    { name = "attrs" },
+    { name = "click" },
+    { name = "cookiecutter" },
+    { name = "gitpython" },
+    { name = "jinja2-time" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "questionary" },
+    { name = "requests-futures" },
+    { name = "rich" },
+    { name = "software-patterns" },
+]
+
+[package.optional-dependencies]
+docs = [
+    { name = "markdown-it-py" },
+    { name = "myst-parser", marker = "python_full_version >= '3.10'" },
+    { name = "sphinx" },
+    { name = "sphinx-autodoc-typehints" },
+    { name = "sphinx-inline-tabs" },
+    { name = "sphinx-rtd-theme" },
+    { name = "sphinxcontrib-mermaid" },
+    { name = "sphinxcontrib-spelling" },
+]
+docslive = [
+    { name = "myst-parser" },
+    { name = "sphinx-autobuild" },
+    { name = "sphinx-inline-tabs" },
+    { name = "sphinxcontrib-mermaid" },
+    { name = "sphinxcontrib-spelling" },
+    { name = "tornado" },
+]
+test = [
+    { name = "build" },
+    { name = "pytest" },
+    { name = "pytest-click" },
+    { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-cov", version = "6.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-explicit" },
+    { name = "pytest-object-getter" },
+    { name = "pytest-requests-futures" },
+    { name = "pytest-run-subprocess" },
+    { name = "pytest-xdist" },
+]
+typing = [
+    { name = "mypy", version = "1.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "mypy", version = "1.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "types-pyyaml", version = "6.0.12.20241230", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "types-pyyaml", version = "6.0.12.20250326", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "types-requests" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "attrs", specifier = ">=21.4.0,<22.0.0" },
+    { name = "build", marker = "extra == 'test'", specifier = ">=1.2.2.post1" },
+    { name = "click", specifier = ">=8,<9" },
+    { name = "cookiecutter", specifier = ">=2.1.1,<3.0.0" },
+    { name = "gitpython", marker = "python_full_version >= '3.7' and python_full_version < '3.13'", specifier = ">=3.1.30,<4.0.0" },
+    { name = "jinja2-time", specifier = ">=0.2.0,<1.0.0" },
+    { name = "markdown-it-py", marker = "python_full_version >= '3.8' and python_full_version < '3.13' and extra == 'docs'", specifier = "==3.0.0" },
+    { name = "mypy", marker = "extra == 'typing'", specifier = ">=1.0.0" },
+    { name = "myst-parser", marker = "python_full_version >= '3.10' and python_full_version < '3.13' and extra == 'docs'", specifier = ">=3.0.0,<4.0.0" },
+    { name = "myst-parser", marker = "extra == 'docslive'", specifier = ">=3.0.1,<5.0.0" },
+    { name = "packaging", specifier = ">=22,<23" },
+    { name = "pytest", marker = "python_full_version >= '3.7' and python_full_version < '3.13' and extra == 'test'", specifier = ">=7.2.0,<8.0.0" },
+    { name = "pytest-click", marker = "extra == 'test'", specifier = "~=1.1.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=2.12" },
+    { name = "pytest-explicit", marker = "extra == 'test'", specifier = "~=1.0.1" },
+    { name = "pytest-object-getter", marker = "extra == 'test'", specifier = ">=1.0.1,<2.0.0" },
+    { name = "pytest-requests-futures", marker = "extra == 'test'", specifier = "==0.9.0" },
+    { name = "pytest-run-subprocess", marker = "extra == 'test'", specifier = "==0.9.0" },
+    { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=1.34" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
+    { name = "questionary", specifier = ">=1.10.0,<2.0.0" },
+    { name = "requests-futures", specifier = ">=1.0.0,<2.0.0" },
+    { name = "rich", marker = "python_full_version >= '3.7' and python_full_version < '3.13'", specifier = ">=13.0.0,<14.0.0" },
+    { name = "software-patterns", specifier = ">=1.3.0,<2.0.0" },
+    { name = "sphinx", marker = "python_full_version >= '3.8' and python_full_version < '3.13' and extra == 'docs'", specifier = "~=6.0" },
+    { name = "sphinx-autobuild", marker = "extra == 'docslive'", specifier = ">=2021.3.14,<2022.0.0" },
+    { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=1.10" },
+    { name = "sphinx-inline-tabs", marker = "python_full_version >= '3.8' and python_full_version < '3.13' and extra == 'docs'", specifier = ">=2023.4.21,<2024.0.0" },
+    { name = "sphinx-inline-tabs", marker = "extra == 'docslive'", specifier = "==2023.4.21" },
+    { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = "==0.5.0" },
+    { name = "sphinxcontrib-mermaid", marker = "python_full_version >= '3.7' and python_full_version < '3.13' and extra == 'docs'", specifier = ">=0.9.2,<1.0.0" },
+    { name = "sphinxcontrib-mermaid", marker = "extra == 'docslive'", specifier = "==0.9.2" },
+    { name = "sphinxcontrib-spelling", marker = "extra == 'docs'", specifier = "~=7.3.3" },
+    { name = "sphinxcontrib-spelling", marker = "extra == 'docslive'", specifier = ">=7.3.3,<8.0.0" },
+    { name = "tornado", marker = "python_full_version >= '3.8' and python_full_version < '3.13' and extra == 'docslive'", specifier = ">=6.3.3,<7.0.0" },
+    { name = "types-pyyaml", marker = "extra == 'typing'", specifier = ">=6.0.12.5,<7.0.0.0" },
+    { name = "types-requests", marker = "extra == 'typing'", specifier = "~=2.27.26" },
+]
+provides-extras = ["test", "docs", "docslive", "typing"]
+
+[[package]]
+name = "coverage"
+version = "7.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/08/7e37f82e4d1aead42a7443ff06a1e406aabf7302c4f00a546e4b320b994c/coverage-7.6.1.tar.gz", hash = "sha256:953510dfb7b12ab69d20135a0662397f077c59b1e6379a768e97c59d852ee51d", size = 798791 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/61/eb7ce5ed62bacf21beca4937a90fe32545c91a3c8a42a30c6616d48fc70d/coverage-7.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b06079abebbc0e89e6163b8e8f0e16270124c154dc6e4a47b413dd538859af16", size = 206690 },
+    { url = "https://files.pythonhosted.org/packages/7d/73/041928e434442bd3afde5584bdc3f932fb4562b1597629f537387cec6f3d/coverage-7.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cf4b19715bccd7ee27b6b120e7e9dd56037b9c0681dcc1adc9ba9db3d417fa36", size = 207127 },
+    { url = "https://files.pythonhosted.org/packages/c7/c8/6ca52b5147828e45ad0242388477fdb90df2c6cbb9a441701a12b3c71bc8/coverage-7.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e61c0abb4c85b095a784ef23fdd4aede7a2628478e7baba7c5e3deba61070a02", size = 235654 },
+    { url = "https://files.pythonhosted.org/packages/d5/da/9ac2b62557f4340270942011d6efeab9833648380109e897d48ab7c1035d/coverage-7.6.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd21f6ae3f08b41004dfb433fa895d858f3f5979e7762d052b12aef444e29afc", size = 233598 },
+    { url = "https://files.pythonhosted.org/packages/53/23/9e2c114d0178abc42b6d8d5281f651a8e6519abfa0ef460a00a91f80879d/coverage-7.6.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f59d57baca39b32db42b83b2a7ba6f47ad9c394ec2076b084c3f029b7afca23", size = 234732 },
+    { url = "https://files.pythonhosted.org/packages/0f/7e/a0230756fb133343a52716e8b855045f13342b70e48e8ad41d8a0d60ab98/coverage-7.6.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a1ac0ae2b8bd743b88ed0502544847c3053d7171a3cff9228af618a068ed9c34", size = 233816 },
+    { url = "https://files.pythonhosted.org/packages/28/7c/3753c8b40d232b1e5eeaed798c875537cf3cb183fb5041017c1fdb7ec14e/coverage-7.6.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e6a08c0be454c3b3beb105c0596ebdc2371fab6bb90c0c0297f4e58fd7e1012c", size = 232325 },
+    { url = "https://files.pythonhosted.org/packages/57/e3/818a2b2af5b7573b4b82cf3e9f137ab158c90ea750a8f053716a32f20f06/coverage-7.6.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f5796e664fe802da4f57a168c85359a8fbf3eab5e55cd4e4569fbacecc903959", size = 233418 },
+    { url = "https://files.pythonhosted.org/packages/c8/fb/4532b0b0cefb3f06d201648715e03b0feb822907edab3935112b61b885e2/coverage-7.6.1-cp310-cp310-win32.whl", hash = "sha256:7bb65125fcbef8d989fa1dd0e8a060999497629ca5b0efbca209588a73356232", size = 209343 },
+    { url = "https://files.pythonhosted.org/packages/5a/25/af337cc7421eca1c187cc9c315f0a755d48e755d2853715bfe8c418a45fa/coverage-7.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:3115a95daa9bdba70aea750db7b96b37259a81a709223c8448fa97727d546fe0", size = 210136 },
+    { url = "https://files.pythonhosted.org/packages/ad/5f/67af7d60d7e8ce61a4e2ddcd1bd5fb787180c8d0ae0fbd073f903b3dd95d/coverage-7.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7dea0889685db8550f839fa202744652e87c60015029ce3f60e006f8c4462c93", size = 206796 },
+    { url = "https://files.pythonhosted.org/packages/e1/0e/e52332389e057daa2e03be1fbfef25bb4d626b37d12ed42ae6281d0a274c/coverage-7.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ed37bd3c3b063412f7620464a9ac1314d33100329f39799255fb8d3027da50d3", size = 207244 },
+    { url = "https://files.pythonhosted.org/packages/aa/cd/766b45fb6e090f20f8927d9c7cb34237d41c73a939358bc881883fd3a40d/coverage-7.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d85f5e9a5f8b73e2350097c3756ef7e785f55bd71205defa0bfdaf96c31616ff", size = 239279 },
+    { url = "https://files.pythonhosted.org/packages/70/6c/a9ccd6fe50ddaf13442a1e2dd519ca805cbe0f1fcd377fba6d8339b98ccb/coverage-7.6.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bc572be474cafb617672c43fe989d6e48d3c83af02ce8de73fff1c6bb3c198d", size = 236859 },
+    { url = "https://files.pythonhosted.org/packages/14/6f/8351b465febb4dbc1ca9929505202db909c5a635c6fdf33e089bbc3d7d85/coverage-7.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0420b573964c760df9e9e86d1a9a622d0d27f417e1a949a8a66dd7bcee7bc6", size = 238549 },
+    { url = "https://files.pythonhosted.org/packages/68/3c/289b81fa18ad72138e6d78c4c11a82b5378a312c0e467e2f6b495c260907/coverage-7.6.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1f4aa8219db826ce6be7099d559f8ec311549bfc4046f7f9fe9b5cea5c581c56", size = 237477 },
+    { url = "https://files.pythonhosted.org/packages/ed/1c/aa1efa6459d822bd72c4abc0b9418cf268de3f60eeccd65dc4988553bd8d/coverage-7.6.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:fc5a77d0c516700ebad189b587de289a20a78324bc54baee03dd486f0855d234", size = 236134 },
+    { url = "https://files.pythonhosted.org/packages/fb/c8/521c698f2d2796565fe9c789c2ee1ccdae610b3aa20b9b2ef980cc253640/coverage-7.6.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b48f312cca9621272ae49008c7f613337c53fadca647d6384cc129d2996d1133", size = 236910 },
+    { url = "https://files.pythonhosted.org/packages/7d/30/033e663399ff17dca90d793ee8a2ea2890e7fdf085da58d82468b4220bf7/coverage-7.6.1-cp311-cp311-win32.whl", hash = "sha256:1125ca0e5fd475cbbba3bb67ae20bd2c23a98fac4e32412883f9bcbaa81c314c", size = 209348 },
+    { url = "https://files.pythonhosted.org/packages/20/05/0d1ccbb52727ccdadaa3ff37e4d2dc1cd4d47f0c3df9eb58d9ec8508ca88/coverage-7.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:8ae539519c4c040c5ffd0632784e21b2f03fc1340752af711f33e5be83a9d6c6", size = 210230 },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/300fc921dff243cd518c7db3a4c614b7e4b2431b0d1145c1e274fd99bd70/coverage-7.6.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:95cae0efeb032af8458fc27d191f85d1717b1d4e49f7cb226cf526ff28179778", size = 206983 },
+    { url = "https://files.pythonhosted.org/packages/e1/ab/6bf00de5327ecb8db205f9ae596885417a31535eeda6e7b99463108782e1/coverage-7.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5621a9175cf9d0b0c84c2ef2b12e9f5f5071357c4d2ea6ca1cf01814f45d2391", size = 207221 },
+    { url = "https://files.pythonhosted.org/packages/92/8f/2ead05e735022d1a7f3a0a683ac7f737de14850395a826192f0288703472/coverage-7.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:260933720fdcd75340e7dbe9060655aff3af1f0c5d20f46b57f262ab6c86a5e8", size = 240342 },
+    { url = "https://files.pythonhosted.org/packages/0f/ef/94043e478201ffa85b8ae2d2c79b4081e5a1b73438aafafccf3e9bafb6b5/coverage-7.6.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07e2ca0ad381b91350c0ed49d52699b625aab2b44b65e1b4e02fa9df0e92ad2d", size = 237371 },
+    { url = "https://files.pythonhosted.org/packages/1f/0f/c890339dd605f3ebc269543247bdd43b703cce6825b5ed42ff5f2d6122c7/coverage-7.6.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c44fee9975f04b33331cb8eb272827111efc8930cfd582e0320613263ca849ca", size = 239455 },
+    { url = "https://files.pythonhosted.org/packages/d1/04/7fd7b39ec7372a04efb0f70c70e35857a99b6a9188b5205efb4c77d6a57a/coverage-7.6.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877abb17e6339d96bf08e7a622d05095e72b71f8afd8a9fefc82cf30ed944163", size = 238924 },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/73ce346a9d32a09cf369f14d2a06651329c984e106f5992c89579d25b27e/coverage-7.6.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3e0cadcf6733c09154b461f1ca72d5416635e5e4ec4e536192180d34ec160f8a", size = 237252 },
+    { url = "https://files.pythonhosted.org/packages/86/74/1dc7a20969725e917b1e07fe71a955eb34bc606b938316bcc799f228374b/coverage-7.6.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c3c02d12f837d9683e5ab2f3d9844dc57655b92c74e286c262e0fc54213c216d", size = 238897 },
+    { url = "https://files.pythonhosted.org/packages/b6/e9/d9cc3deceb361c491b81005c668578b0dfa51eed02cd081620e9a62f24ec/coverage-7.6.1-cp312-cp312-win32.whl", hash = "sha256:e05882b70b87a18d937ca6768ff33cc3f72847cbc4de4491c8e73880766718e5", size = 209606 },
+    { url = "https://files.pythonhosted.org/packages/47/c8/5a2e41922ea6740f77d555c4d47544acd7dc3f251fe14199c09c0f5958d3/coverage-7.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:b5d7b556859dd85f3a541db6a4e0167b86e7273e1cdc973e5b175166bb634fdb", size = 210373 },
+    { url = "https://files.pythonhosted.org/packages/81/d0/d9e3d554e38beea5a2e22178ddb16587dbcbe9a1ef3211f55733924bf7fa/coverage-7.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6db04803b6c7291985a761004e9060b2bca08da6d04f26a7f2294b8623a0c1a0", size = 206674 },
+    { url = "https://files.pythonhosted.org/packages/38/ea/cab2dc248d9f45b2b7f9f1f596a4d75a435cb364437c61b51d2eb33ceb0e/coverage-7.6.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f1adfc8ac319e1a348af294106bc6a8458a0f1633cc62a1446aebc30c5fa186a", size = 207101 },
+    { url = "https://files.pythonhosted.org/packages/ca/6f/f82f9a500c7c5722368978a5390c418d2a4d083ef955309a8748ecaa8920/coverage-7.6.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a95324a9de9650a729239daea117df21f4b9868ce32e63f8b650ebe6cef5595b", size = 236554 },
+    { url = "https://files.pythonhosted.org/packages/a6/94/d3055aa33d4e7e733d8fa309d9adf147b4b06a82c1346366fc15a2b1d5fa/coverage-7.6.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b43c03669dc4618ec25270b06ecd3ee4fa94c7f9b3c14bae6571ca00ef98b0d3", size = 234440 },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/885bcd787d9dd674de4a7d8ec83faf729534c63d05d51d45d4fa168f7102/coverage-7.6.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8929543a7192c13d177b770008bc4e8119f2e1f881d563fc6b6305d2d0ebe9de", size = 235889 },
+    { url = "https://files.pythonhosted.org/packages/f4/63/df50120a7744492710854860783d6819ff23e482dee15462c9a833cc428a/coverage-7.6.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:a09ece4a69cf399510c8ab25e0950d9cf2b42f7b3cb0374f95d2e2ff594478a6", size = 235142 },
+    { url = "https://files.pythonhosted.org/packages/3a/5d/9d0acfcded2b3e9ce1c7923ca52ccc00c78a74e112fc2aee661125b7843b/coverage-7.6.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:9054a0754de38d9dbd01a46621636689124d666bad1936d76c0341f7d71bf569", size = 233805 },
+    { url = "https://files.pythonhosted.org/packages/c4/56/50abf070cb3cd9b1dd32f2c88f083aab561ecbffbcd783275cb51c17f11d/coverage-7.6.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:0dbde0f4aa9a16fa4d754356a8f2e36296ff4d83994b2c9d8398aa32f222f989", size = 234655 },
+    { url = "https://files.pythonhosted.org/packages/25/ee/b4c246048b8485f85a2426ef4abab88e48c6e80c74e964bea5cd4cd4b115/coverage-7.6.1-cp38-cp38-win32.whl", hash = "sha256:da511e6ad4f7323ee5702e6633085fb76c2f893aaf8ce4c51a0ba4fc07580ea7", size = 209296 },
+    { url = "https://files.pythonhosted.org/packages/5c/1c/96cf86b70b69ea2b12924cdf7cabb8ad10e6130eab8d767a1099fbd2a44f/coverage-7.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:3f1156e3e8f2872197af3840d8ad307a9dd18e615dc64d9ee41696f287c57ad8", size = 210137 },
+    { url = "https://files.pythonhosted.org/packages/19/d3/d54c5aa83268779d54c86deb39c1c4566e5d45c155369ca152765f8db413/coverage-7.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abd5fd0db5f4dc9289408aaf34908072f805ff7792632250dcb36dc591d24255", size = 206688 },
+    { url = "https://files.pythonhosted.org/packages/a5/fe/137d5dca72e4a258b1bc17bb04f2e0196898fe495843402ce826a7419fe3/coverage-7.6.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:547f45fa1a93154bd82050a7f3cddbc1a7a4dd2a9bf5cb7d06f4ae29fe94eaf8", size = 207120 },
+    { url = "https://files.pythonhosted.org/packages/78/5b/a0a796983f3201ff5485323b225d7c8b74ce30c11f456017e23d8e8d1945/coverage-7.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645786266c8f18a931b65bfcefdbf6952dd0dea98feee39bd188607a9d307ed2", size = 235249 },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/76089d6a5ef9d68f018f65411fcdaaeb0141b504587b901d74e8587606ad/coverage-7.6.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9e0b2df163b8ed01d515807af24f63de04bebcecbd6c3bfeff88385789fdf75a", size = 233237 },
+    { url = "https://files.pythonhosted.org/packages/9a/6f/eef79b779a540326fee9520e5542a8b428cc3bfa8b7c8f1022c1ee4fc66c/coverage-7.6.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:609b06f178fe8e9f89ef676532760ec0b4deea15e9969bf754b37f7c40326dbc", size = 234311 },
+    { url = "https://files.pythonhosted.org/packages/75/e1/656d65fb126c29a494ef964005702b012f3498db1a30dd562958e85a4049/coverage-7.6.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:702855feff378050ae4f741045e19a32d57d19f3e0676d589df0575008ea5004", size = 233453 },
+    { url = "https://files.pythonhosted.org/packages/68/6a/45f108f137941a4a1238c85f28fd9d048cc46b5466d6b8dda3aba1bb9d4f/coverage-7.6.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:2bdb062ea438f22d99cba0d7829c2ef0af1d768d1e4a4f528087224c90b132cb", size = 231958 },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/47b809099168b8b8c72ae311efc3e88c8d8a1162b3ba4b8da3cfcdb85743/coverage-7.6.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:9c56863d44bd1c4fe2abb8a4d6f5371d197f1ac0ebdee542f07f35895fc07f36", size = 232938 },
+    { url = "https://files.pythonhosted.org/packages/52/80/052222ba7058071f905435bad0ba392cc12006380731c37afaf3fe749b88/coverage-7.6.1-cp39-cp39-win32.whl", hash = "sha256:6e2cd258d7d927d09493c8df1ce9174ad01b381d4729a9d8d4e38670ca24774c", size = 209352 },
+    { url = "https://files.pythonhosted.org/packages/b8/d8/1b92e0b3adcf384e98770a00ca095da1b5f7b483e6563ae4eb5e935d24a1/coverage-7.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:06a737c882bd26d0d6ee7269b20b12f14a8704807a01056c80bb881a4b2ce6ca", size = 210153 },
+    { url = "https://files.pythonhosted.org/packages/a5/2b/0354ed096bca64dc8e32a7cbcae28b34cb5ad0b1fe2125d6d99583313ac0/coverage-7.6.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:e9a6e0eb86070e8ccaedfbd9d38fec54864f3125ab95419970575b42af7541df", size = 198926 },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version < '3.9'" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/4f/2251e65033ed2ce1e68f00f91a0294e0f80c80ae8c3ebbe2f12828c4cd53/coverage-7.8.0.tar.gz", hash = "sha256:7a3d62b3b03b4b6fd41a085f3574874cf946cb4604d2b4d3e8dca8cd570ca501", size = 811872 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/01/1c5e6ee4ebaaa5e079db933a9a45f61172048c7efa06648445821a201084/coverage-7.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2931f66991175369859b5fd58529cd4b73582461877ecfd859b6549869287ffe", size = 211379 },
+    { url = "https://files.pythonhosted.org/packages/e9/16/a463389f5ff916963471f7c13585e5f38c6814607306b3cb4d6b4cf13384/coverage-7.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52a523153c568d2c0ef8826f6cc23031dc86cffb8c6aeab92c4ff776e7951b28", size = 211814 },
+    { url = "https://files.pythonhosted.org/packages/b8/b1/77062b0393f54d79064dfb72d2da402657d7c569cfbc724d56ac0f9c67ed/coverage-7.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c8a5c139aae4c35cbd7cadca1df02ea8cf28a911534fc1b0456acb0b14234f3", size = 240937 },
+    { url = "https://files.pythonhosted.org/packages/d7/54/c7b00a23150083c124e908c352db03bcd33375494a4beb0c6d79b35448b9/coverage-7.8.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a26c0c795c3e0b63ec7da6efded5f0bc856d7c0b24b2ac84b4d1d7bc578d676", size = 238849 },
+    { url = "https://files.pythonhosted.org/packages/f7/ec/a6b7cfebd34e7b49f844788fda94713035372b5200c23088e3bbafb30970/coverage-7.8.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:821f7bcbaa84318287115d54becb1915eece6918136c6f91045bb84e2f88739d", size = 239986 },
+    { url = "https://files.pythonhosted.org/packages/21/8c/c965ecef8af54e6d9b11bfbba85d4f6a319399f5f724798498387f3209eb/coverage-7.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a321c61477ff8ee705b8a5fed370b5710c56b3a52d17b983d9215861e37b642a", size = 239896 },
+    { url = "https://files.pythonhosted.org/packages/40/83/070550273fb4c480efa8381735969cb403fa8fd1626d74865bfaf9e4d903/coverage-7.8.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:ed2144b8a78f9d94d9515963ed273d620e07846acd5d4b0a642d4849e8d91a0c", size = 238613 },
+    { url = "https://files.pythonhosted.org/packages/07/76/fbb2540495b01d996d38e9f8897b861afed356be01160ab4e25471f4fed1/coverage-7.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:042e7841a26498fff7a37d6fda770d17519982f5b7d8bf5278d140b67b61095f", size = 238909 },
+    { url = "https://files.pythonhosted.org/packages/a3/7e/76d604db640b7d4a86e5dd730b73e96e12a8185f22b5d0799025121f4dcb/coverage-7.8.0-cp310-cp310-win32.whl", hash = "sha256:f9983d01d7705b2d1f7a95e10bbe4091fabc03a46881a256c2787637b087003f", size = 213948 },
+    { url = "https://files.pythonhosted.org/packages/5c/a7/f8ce4aafb4a12ab475b56c76a71a40f427740cf496c14e943ade72e25023/coverage-7.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:5a570cd9bd20b85d1a0d7b009aaf6c110b52b5755c17be6962f8ccd65d1dbd23", size = 214844 },
+    { url = "https://files.pythonhosted.org/packages/2b/77/074d201adb8383addae5784cb8e2dac60bb62bfdf28b2b10f3a3af2fda47/coverage-7.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7ac22a0bb2c7c49f441f7a6d46c9c80d96e56f5a8bc6972529ed43c8b694e27", size = 211493 },
+    { url = "https://files.pythonhosted.org/packages/a9/89/7a8efe585750fe59b48d09f871f0e0c028a7b10722b2172dfe021fa2fdd4/coverage-7.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf13d564d310c156d1c8e53877baf2993fb3073b2fc9f69790ca6a732eb4bfea", size = 211921 },
+    { url = "https://files.pythonhosted.org/packages/e9/ef/96a90c31d08a3f40c49dbe897df4f1fd51fb6583821a1a1c5ee30cc8f680/coverage-7.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5761c70c017c1b0d21b0815a920ffb94a670c8d5d409d9b38857874c21f70d7", size = 244556 },
+    { url = "https://files.pythonhosted.org/packages/89/97/dcd5c2ce72cee9d7b0ee8c89162c24972fb987a111b92d1a3d1d19100c61/coverage-7.8.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5ff52d790c7e1628241ffbcaeb33e07d14b007b6eb00a19320c7b8a7024c040", size = 242245 },
+    { url = "https://files.pythonhosted.org/packages/b2/7b/b63cbb44096141ed435843bbb251558c8e05cc835c8da31ca6ffb26d44c0/coverage-7.8.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d39fc4817fd67b3915256af5dda75fd4ee10621a3d484524487e33416c6f3543", size = 244032 },
+    { url = "https://files.pythonhosted.org/packages/97/e3/7fa8c2c00a1ef530c2a42fa5df25a6971391f92739d83d67a4ee6dcf7a02/coverage-7.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b44674870709017e4b4036e3d0d6c17f06a0e6d4436422e0ad29b882c40697d2", size = 243679 },
+    { url = "https://files.pythonhosted.org/packages/4f/b3/e0a59d8df9150c8a0c0841d55d6568f0a9195692136c44f3d21f1842c8f6/coverage-7.8.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8f99eb72bf27cbb167b636eb1726f590c00e1ad375002230607a844d9e9a2318", size = 241852 },
+    { url = "https://files.pythonhosted.org/packages/9b/82/db347ccd57bcef150c173df2ade97976a8367a3be7160e303e43dd0c795f/coverage-7.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b571bf5341ba8c6bc02e0baeaf3b061ab993bf372d982ae509807e7f112554e9", size = 242389 },
+    { url = "https://files.pythonhosted.org/packages/21/f6/3f7d7879ceb03923195d9ff294456241ed05815281f5254bc16ef71d6a20/coverage-7.8.0-cp311-cp311-win32.whl", hash = "sha256:e75a2ad7b647fd8046d58c3132d7eaf31b12d8a53c0e4b21fa9c4d23d6ee6d3c", size = 213997 },
+    { url = "https://files.pythonhosted.org/packages/28/87/021189643e18ecf045dbe1e2071b2747901f229df302de01c998eeadf146/coverage-7.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:3043ba1c88b2139126fc72cb48574b90e2e0546d4c78b5299317f61b7f718b78", size = 214911 },
+    { url = "https://files.pythonhosted.org/packages/aa/12/4792669473297f7973518bec373a955e267deb4339286f882439b8535b39/coverage-7.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bbb5cc845a0292e0c520656d19d7ce40e18d0e19b22cb3e0409135a575bf79fc", size = 211684 },
+    { url = "https://files.pythonhosted.org/packages/be/e1/2a4ec273894000ebedd789e8f2fc3813fcaf486074f87fd1c5b2cb1c0a2b/coverage-7.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4dfd9a93db9e78666d178d4f08a5408aa3f2474ad4d0e0378ed5f2ef71640cb6", size = 211935 },
+    { url = "https://files.pythonhosted.org/packages/f8/3a/7b14f6e4372786709a361729164125f6b7caf4024ce02e596c4a69bccb89/coverage-7.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f017a61399f13aa6d1039f75cd467be388d157cd81f1a119b9d9a68ba6f2830d", size = 245994 },
+    { url = "https://files.pythonhosted.org/packages/54/80/039cc7f1f81dcbd01ea796d36d3797e60c106077e31fd1f526b85337d6a1/coverage-7.8.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0915742f4c82208ebf47a2b154a5334155ed9ef9fe6190674b8a46c2fb89cb05", size = 242885 },
+    { url = "https://files.pythonhosted.org/packages/10/e0/dc8355f992b6cc2f9dcd5ef6242b62a3f73264893bc09fbb08bfcab18eb4/coverage-7.8.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a40fcf208e021eb14b0fac6bdb045c0e0cab53105f93ba0d03fd934c956143a", size = 245142 },
+    { url = "https://files.pythonhosted.org/packages/43/1b/33e313b22cf50f652becb94c6e7dae25d8f02e52e44db37a82de9ac357e8/coverage-7.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a1f406a8e0995d654b2ad87c62caf6befa767885301f3b8f6f73e6f3c31ec3a6", size = 244906 },
+    { url = "https://files.pythonhosted.org/packages/05/08/c0a8048e942e7f918764ccc99503e2bccffba1c42568693ce6955860365e/coverage-7.8.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:77af0f6447a582fdc7de5e06fa3757a3ef87769fbb0fdbdeba78c23049140a47", size = 243124 },
+    { url = "https://files.pythonhosted.org/packages/5b/62/ea625b30623083c2aad645c9a6288ad9fc83d570f9adb913a2abdba562dd/coverage-7.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f2d32f95922927186c6dbc8bc60df0d186b6edb828d299ab10898ef3f40052fe", size = 244317 },
+    { url = "https://files.pythonhosted.org/packages/62/cb/3871f13ee1130a6c8f020e2f71d9ed269e1e2124aa3374d2180ee451cee9/coverage-7.8.0-cp312-cp312-win32.whl", hash = "sha256:769773614e676f9d8e8a0980dd7740f09a6ea386d0f383db6821df07d0f08545", size = 214170 },
+    { url = "https://files.pythonhosted.org/packages/88/26/69fe1193ab0bfa1eb7a7c0149a066123611baba029ebb448500abd8143f9/coverage-7.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:e5d2b9be5b0693cf21eb4ce0ec8d211efb43966f6657807f6859aab3814f946b", size = 214969 },
+    { url = "https://files.pythonhosted.org/packages/60/0c/5da94be095239814bf2730a28cffbc48d6df4304e044f80d39e1ae581997/coverage-7.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fa260de59dfb143af06dcf30c2be0b200bed2a73737a8a59248fcb9fa601ef0f", size = 211377 },
+    { url = "https://files.pythonhosted.org/packages/d5/cb/b9e93ebf193a0bb89dbcd4f73d7b0e6ecb7c1b6c016671950e25f041835e/coverage-7.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:96121edfa4c2dfdda409877ea8608dd01de816a4dc4a0523356067b305e4e17a", size = 211803 },
+    { url = "https://files.pythonhosted.org/packages/78/1a/cdbfe9e1bb14d3afcaf6bb6e1b9ba76c72666e329cd06865bbd241efd652/coverage-7.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b8af63b9afa1031c0ef05b217faa598f3069148eeee6bb24b79da9012423b82", size = 240561 },
+    { url = "https://files.pythonhosted.org/packages/59/04/57f1223f26ac018d7ce791bfa65b0c29282de3e041c1cd3ed430cfeac5a5/coverage-7.8.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:89b1f4af0d4afe495cd4787a68e00f30f1d15939f550e869de90a86efa7e0814", size = 238488 },
+    { url = "https://files.pythonhosted.org/packages/b7/b1/0f25516ae2a35e265868670384feebe64e7857d9cffeeb3887b0197e2ba2/coverage-7.8.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94ec0be97723ae72d63d3aa41961a0b9a6f5a53ff599813c324548d18e3b9e8c", size = 239589 },
+    { url = "https://files.pythonhosted.org/packages/e0/a4/99d88baac0d1d5a46ceef2dd687aac08fffa8795e4c3e71b6f6c78e14482/coverage-7.8.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8a1d96e780bdb2d0cbb297325711701f7c0b6f89199a57f2049e90064c29f6bd", size = 239366 },
+    { url = "https://files.pythonhosted.org/packages/ea/9e/1db89e135feb827a868ed15f8fc857160757f9cab140ffee21342c783ceb/coverage-7.8.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f1d8a2a57b47142b10374902777e798784abf400a004b14f1b0b9eaf1e528ba4", size = 237591 },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/ac4d6fdfd0e201bc82d1b08adfacb1e34b40d21a22cdd62cfaf3c1828566/coverage-7.8.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cf60dd2696b457b710dd40bf17ad269d5f5457b96442f7f85722bdb16fa6c899", size = 238572 },
+    { url = "https://files.pythonhosted.org/packages/25/5e/917cbe617c230f7f1745b6a13e780a3a1cd1cf328dbcd0fd8d7ec52858cd/coverage-7.8.0-cp39-cp39-win32.whl", hash = "sha256:be945402e03de47ba1872cd5236395e0f4ad635526185a930735f66710e1bd3f", size = 213966 },
+    { url = "https://files.pythonhosted.org/packages/bd/93/72b434fe550135869f9ea88dd36068af19afce666db576e059e75177e813/coverage-7.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:90e7fbc6216ecaffa5a880cdc9c77b7418c1dcb166166b78dbc630d07f278cc3", size = 214852 },
+    { url = "https://files.pythonhosted.org/packages/c4/f1/1da77bb4c920aa30e82fa9b6ea065da3467977c2e5e032e38e66f1c57ffd/coverage-7.8.0-pp39.pp310.pp311-none-any.whl", hash = "sha256:b8194fb8e50d556d5849753de991d390c5a1edeeba50f68e3a9253fbd8bf8ccd", size = 203443 },
+    { url = "https://files.pythonhosted.org/packages/59/f1/4da7717f0063a222db253e7121bd6a56f6fb1ba439dcc36659088793347c/coverage-7.8.0-py3-none-any.whl", hash = "sha256:dbf364b4c5e7bae9250528167dfe40219b62e2d573c854d74be213e1e52069f7", size = 203435 },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version >= '3.9' and python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/330ea8d383eb2ce973df34d1239b3b21e91cd8c865d21ff82902d952f91f/docutils-0.19.tar.gz", hash = "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6", size = 2056383 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl", hash = "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc", size = 570472 },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453 },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612 },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794 },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.44"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/89/37df0b71473153574a5cdef8f242de422a0f5d26d7a9e231e6f169b4ad14/gitpython-3.1.44.tar.gz", hash = "sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269", size = 214196 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/9a/4114a9057db2f1462d5c8f8390ab7383925fe1ac012eaa42402ad65c2963/GitPython-3.1.44-py3-none-any.whl", hash = "sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110", size = 207599 },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+]
+
+[[package]]
+name = "imagesize"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a", size = 1280026 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b", size = 8769 },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "zipp", version = "3.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7", size = 55304 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b", size = 26514 },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "zipp", version = "3.21.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/08/c1395a292bb23fd03bdf572a1357c5a733d3eecbab877641ceacab23db6e/importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580", size = 55767 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e", size = 26971 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe", version = "2.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "markupsafe", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
+]
+
+[[package]]
+name = "jinja2-time"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/7c/ee2f2014a2a0616ad3328e58e7dac879251babdb4cb796d770b5d32c469f/jinja2-time-0.2.0.tar.gz", hash = "sha256:d14eaa4d315e7688daa4969f616f226614350c48730bfa1692d2caebd8c90d40", size = 5701 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/a1/d44fa38306ffa34a7e1af09632b158e13ec89670ce491f8a15af3ebcb4e4/jinja2_time-0.2.0-py2.py3-none-any.whl", hash = "sha256:d3eab6605e3ec8b7a0863df09cc1d23714908fa61aa6986a845c20ba488b4efa", size = 6360 },
+]
+
+[[package]]
+name = "livereload"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/6e/f2748665839812a9bbe5c75d3f983edbf3ab05fa5cd2f7c2f36fffdf65bd/livereload-2.7.1.tar.gz", hash = "sha256:3d9bf7c05673df06e32bea23b494b8d36ca6d10f7d5c3c8a6989608c09c986a9", size = 22255 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/3e/de54dc7f199e85e6ca37e2e5dae2ec3bce2151e9e28f8eb9076d71e83d56/livereload-2.7.1-py3-none-any.whl", hash = "sha256:5201740078c1b9433f4b2ba22cd2729a39b9d0ec0a2cc6b4d3df257df5ad0564", size = 22657 },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "markupsafe"
+version = "2.1.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b", size = 19384 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/54/ad5eb37bf9d51800010a74e4665425831a9db4e7c4e0fde4352e391e808e/MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc", size = 18206 },
+    { url = "https://files.pythonhosted.org/packages/6a/4a/a4d49415e600bacae038c67f9fecc1d5433b9d3c71a4de6f33537b89654c/MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5", size = 14079 },
+    { url = "https://files.pythonhosted.org/packages/0a/7b/85681ae3c33c385b10ac0f8dd025c30af83c78cec1c37a6aa3b55e67f5ec/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46", size = 26620 },
+    { url = "https://files.pythonhosted.org/packages/7c/52/2b1b570f6b8b803cef5ac28fdf78c0da318916c7d2fe9402a84d591b394c/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f", size = 25818 },
+    { url = "https://files.pythonhosted.org/packages/29/fe/a36ba8c7ca55621620b2d7c585313efd10729e63ef81e4e61f52330da781/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900", size = 25493 },
+    { url = "https://files.pythonhosted.org/packages/60/ae/9c60231cdfda003434e8bd27282b1f4e197ad5a710c14bee8bea8a9ca4f0/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff", size = 30630 },
+    { url = "https://files.pythonhosted.org/packages/65/dc/1510be4d179869f5dafe071aecb3f1f41b45d37c02329dfba01ff59e5ac5/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad", size = 29745 },
+    { url = "https://files.pythonhosted.org/packages/30/39/8d845dd7d0b0613d86e0ef89549bfb5f61ed781f59af45fc96496e897f3a/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd", size = 30021 },
+    { url = "https://files.pythonhosted.org/packages/c7/5c/356a6f62e4f3c5fbf2602b4771376af22a3b16efa74eb8716fb4e328e01e/MarkupSafe-2.1.5-cp310-cp310-win32.whl", hash = "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4", size = 16659 },
+    { url = "https://files.pythonhosted.org/packages/69/48/acbf292615c65f0604a0c6fc402ce6d8c991276e16c80c46a8f758fbd30c/MarkupSafe-2.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5", size = 17213 },
+    { url = "https://files.pythonhosted.org/packages/11/e7/291e55127bb2ae67c64d66cef01432b5933859dfb7d6949daa721b89d0b3/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f", size = 18219 },
+    { url = "https://files.pythonhosted.org/packages/6b/cb/aed7a284c00dfa7c0682d14df85ad4955a350a21d2e3b06d8240497359bf/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2", size = 14098 },
+    { url = "https://files.pythonhosted.org/packages/1c/cf/35fe557e53709e93feb65575c93927942087e9b97213eabc3fe9d5b25a55/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced", size = 29014 },
+    { url = "https://files.pythonhosted.org/packages/97/18/c30da5e7a0e7f4603abfc6780574131221d9148f323752c2755d48abad30/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5", size = 28220 },
+    { url = "https://files.pythonhosted.org/packages/0c/40/2e73e7d532d030b1e41180807a80d564eda53babaf04d65e15c1cf897e40/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c", size = 27756 },
+    { url = "https://files.pythonhosted.org/packages/18/46/5dca760547e8c59c5311b332f70605d24c99d1303dd9a6e1fc3ed0d73561/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f", size = 33988 },
+    { url = "https://files.pythonhosted.org/packages/6d/c5/27febe918ac36397919cd4a67d5579cbbfa8da027fa1238af6285bb368ea/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a", size = 32718 },
+    { url = "https://files.pythonhosted.org/packages/f8/81/56e567126a2c2bc2684d6391332e357589a96a76cb9f8e5052d85cb0ead8/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f", size = 33317 },
+    { url = "https://files.pythonhosted.org/packages/00/0b/23f4b2470accb53285c613a3ab9ec19dc944eaf53592cb6d9e2af8aa24cc/MarkupSafe-2.1.5-cp311-cp311-win32.whl", hash = "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906", size = 16670 },
+    { url = "https://files.pythonhosted.org/packages/b7/a2/c78a06a9ec6d04b3445a949615c4c7ed86a0b2eb68e44e7541b9d57067cc/MarkupSafe-2.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617", size = 17224 },
+    { url = "https://files.pythonhosted.org/packages/53/bd/583bf3e4c8d6a321938c13f49d44024dbe5ed63e0a7ba127e454a66da974/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1", size = 18215 },
+    { url = "https://files.pythonhosted.org/packages/48/d6/e7cd795fc710292c3af3a06d80868ce4b02bfbbf370b7cee11d282815a2a/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4", size = 14069 },
+    { url = "https://files.pythonhosted.org/packages/51/b5/5d8ec796e2a08fc814a2c7d2584b55f889a55cf17dd1a90f2beb70744e5c/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee", size = 29452 },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/2454f072fae3b5a137c119abf15465d1771319dfe9e4acbb31722a0fff91/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5", size = 28462 },
+    { url = "https://files.pythonhosted.org/packages/2d/75/fd6cb2e68780f72d47e6671840ca517bda5ef663d30ada7616b0462ad1e3/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b", size = 27869 },
+    { url = "https://files.pythonhosted.org/packages/b0/81/147c477391c2750e8fc7705829f7351cf1cd3be64406edcf900dc633feb2/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a", size = 33906 },
+    { url = "https://files.pythonhosted.org/packages/8b/ff/9a52b71839d7a256b563e85d11050e307121000dcebc97df120176b3ad93/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f", size = 32296 },
+    { url = "https://files.pythonhosted.org/packages/88/07/2dc76aa51b481eb96a4c3198894f38b480490e834479611a4053fbf08623/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169", size = 33038 },
+    { url = "https://files.pythonhosted.org/packages/96/0c/620c1fb3661858c0e37eb3cbffd8c6f732a67cd97296f725789679801b31/MarkupSafe-2.1.5-cp312-cp312-win32.whl", hash = "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad", size = 16572 },
+    { url = "https://files.pythonhosted.org/packages/3f/14/c3554d512d5f9100a95e737502f4a2323a1959f6d0d01e0d0997b35f7b10/MarkupSafe-2.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb", size = 17127 },
+    { url = "https://files.pythonhosted.org/packages/f8/ff/2c942a82c35a49df5de3a630ce0a8456ac2969691b230e530ac12314364c/MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a", size = 18192 },
+    { url = "https://files.pythonhosted.org/packages/4f/14/6f294b9c4f969d0c801a4615e221c1e084722ea6114ab2114189c5b8cbe0/MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46", size = 14072 },
+    { url = "https://files.pythonhosted.org/packages/81/d4/fd74714ed30a1dedd0b82427c02fa4deec64f173831ec716da11c51a50aa/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532", size = 26928 },
+    { url = "https://files.pythonhosted.org/packages/c7/bd/50319665ce81bb10e90d1cf76f9e1aa269ea6f7fa30ab4521f14d122a3df/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab", size = 26106 },
+    { url = "https://files.pythonhosted.org/packages/4c/6f/f2b0f675635b05f6afd5ea03c094557bdb8622fa8e673387444fe8d8e787/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68", size = 25781 },
+    { url = "https://files.pythonhosted.org/packages/51/e0/393467cf899b34a9d3678e78961c2c8cdf49fb902a959ba54ece01273fb1/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0", size = 30518 },
+    { url = "https://files.pythonhosted.org/packages/f6/02/5437e2ad33047290dafced9df741d9efc3e716b75583bbd73a9984f1b6f7/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4", size = 29669 },
+    { url = "https://files.pythonhosted.org/packages/0e/7d/968284145ffd9d726183ed6237c77938c021abacde4e073020f920e060b2/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3", size = 29933 },
+    { url = "https://files.pythonhosted.org/packages/bf/f3/ecb00fc8ab02b7beae8699f34db9357ae49d9f21d4d3de6f305f34fa949e/MarkupSafe-2.1.5-cp38-cp38-win32.whl", hash = "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff", size = 16656 },
+    { url = "https://files.pythonhosted.org/packages/92/21/357205f03514a49b293e214ac39de01fadd0970a6e05e4bf1ddd0ffd0881/MarkupSafe-2.1.5-cp38-cp38-win_amd64.whl", hash = "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029", size = 17206 },
+    { url = "https://files.pythonhosted.org/packages/0f/31/780bb297db036ba7b7bbede5e1d7f1e14d704ad4beb3ce53fb495d22bc62/MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf", size = 18193 },
+    { url = "https://files.pythonhosted.org/packages/6c/77/d77701bbef72892affe060cdacb7a2ed7fd68dae3b477a8642f15ad3b132/MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2", size = 14073 },
+    { url = "https://files.pythonhosted.org/packages/d9/a7/1e558b4f78454c8a3a0199292d96159eb4d091f983bc35ef258314fe7269/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8", size = 26486 },
+    { url = "https://files.pythonhosted.org/packages/5f/5a/360da85076688755ea0cceb92472923086993e86b5613bbae9fbc14136b0/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3", size = 25685 },
+    { url = "https://files.pythonhosted.org/packages/6a/18/ae5a258e3401f9b8312f92b028c54d7026a97ec3ab20bfaddbdfa7d8cce8/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465", size = 25338 },
+    { url = "https://files.pythonhosted.org/packages/0b/cc/48206bd61c5b9d0129f4d75243b156929b04c94c09041321456fd06a876d/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e", size = 30439 },
+    { url = "https://files.pythonhosted.org/packages/d1/06/a41c112ab9ffdeeb5f77bc3e331fdadf97fa65e52e44ba31880f4e7f983c/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea", size = 29531 },
+    { url = "https://files.pythonhosted.org/packages/02/8c/ab9a463301a50dab04d5472e998acbd4080597abc048166ded5c7aa768c8/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6", size = 29823 },
+    { url = "https://files.pythonhosted.org/packages/bc/29/9bc18da763496b055d8e98ce476c8e718dcfd78157e17f555ce6dd7d0895/MarkupSafe-2.1.5-cp39-cp39-win32.whl", hash = "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf", size = 16658 },
+    { url = "https://files.pythonhosted.org/packages/f6/f8/4da07de16f10551ca1f640c92b5f316f9394088b183c6a57183df6de5ae4/MarkupSafe-2.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5", size = 17211 },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/90/d08277ce111dd22f77149fd1a5d4653eeb3b3eaacbdfcbae5afb2600eebd/MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8", size = 14357 },
+    { url = "https://files.pythonhosted.org/packages/04/e1/6e2194baeae0bca1fae6629dc0cbbb968d4d941469cbab11a3872edff374/MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158", size = 12393 },
+    { url = "https://files.pythonhosted.org/packages/1d/69/35fa85a8ece0a437493dc61ce0bb6d459dcba482c34197e3efc829aa357f/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579", size = 21732 },
+    { url = "https://files.pythonhosted.org/packages/22/35/137da042dfb4720b638d2937c38a9c2df83fe32d20e8c8f3185dbfef05f7/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d", size = 20866 },
+    { url = "https://files.pythonhosted.org/packages/29/28/6d029a903727a1b62edb51863232152fd335d602def598dade38996887f0/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb", size = 20964 },
+    { url = "https://files.pythonhosted.org/packages/cc/cd/07438f95f83e8bc028279909d9c9bd39e24149b0d60053a97b2bc4f8aa51/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b", size = 21977 },
+    { url = "https://files.pythonhosted.org/packages/29/01/84b57395b4cc062f9c4c55ce0df7d3108ca32397299d9df00fedd9117d3d/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c", size = 21366 },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/61ebf08d8940553afff20d1fb1ba7294b6f8d279df9fd0c0db911b4bbcfd/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171", size = 21091 },
+    { url = "https://files.pythonhosted.org/packages/11/23/ffbf53694e8c94ebd1e7e491de185124277964344733c45481f32ede2499/MarkupSafe-3.0.2-cp310-cp310-win32.whl", hash = "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50", size = 15065 },
+    { url = "https://files.pythonhosted.org/packages/44/06/e7175d06dd6e9172d4a69a72592cb3f7a996a9c396eee29082826449bbc3/MarkupSafe-3.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a", size = 15514 },
+    { url = "https://files.pythonhosted.org/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353 },
+    { url = "https://files.pythonhosted.org/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392 },
+    { url = "https://files.pythonhosted.org/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984 },
+    { url = "https://files.pythonhosted.org/packages/f1/a4/aefb044a2cd8d7334c8a47d3fb2c9f328ac48cb349468cc31c20b539305f/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84", size = 23120 },
+    { url = "https://files.pythonhosted.org/packages/8d/21/5e4851379f88f3fad1de30361db501300d4f07bcad047d3cb0449fc51f8c/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca", size = 23032 },
+    { url = "https://files.pythonhosted.org/packages/00/7b/e92c64e079b2d0d7ddf69899c98842f3f9a60a1ae72657c89ce2655c999d/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798", size = 24057 },
+    { url = "https://files.pythonhosted.org/packages/f9/ac/46f960ca323037caa0a10662ef97d0a4728e890334fc156b9f9e52bcc4ca/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e", size = 23359 },
+    { url = "https://files.pythonhosted.org/packages/69/84/83439e16197337b8b14b6a5b9c2105fff81d42c2a7c5b58ac7b62ee2c3b1/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4", size = 23306 },
+    { url = "https://files.pythonhosted.org/packages/9a/34/a15aa69f01e2181ed8d2b685c0d2f6655d5cca2c4db0ddea775e631918cd/MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d", size = 15094 },
+    { url = "https://files.pythonhosted.org/packages/da/b8/3a3bd761922d416f3dc5d00bfbed11f66b1ab89a0c2b6e887240a30b0f6b/MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b", size = 15521 },
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348 },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149 },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118 },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993 },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178 },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319 },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352 },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097 },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601 },
+    { url = "https://files.pythonhosted.org/packages/a7/ea/9b1530c3fdeeca613faeb0fb5cbcf2389d816072fab72a71b45749ef6062/MarkupSafe-3.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:eaa0a10b7f72326f1372a713e73c3f739b524b3af41feb43e4921cb529f5929a", size = 14344 },
+    { url = "https://files.pythonhosted.org/packages/4b/c2/fbdbfe48848e7112ab05e627e718e854d20192b674952d9042ebd8c9e5de/MarkupSafe-3.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:48032821bbdf20f5799ff537c7ac3d1fba0ba032cfc06194faffa8cda8b560ff", size = 12389 },
+    { url = "https://files.pythonhosted.org/packages/f0/25/7a7c6e4dbd4f867d95d94ca15449e91e52856f6ed1905d58ef1de5e211d0/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a9d3f5f0901fdec14d8d2f66ef7d035f2157240a433441719ac9a3fba440b13", size = 21607 },
+    { url = "https://files.pythonhosted.org/packages/53/8f/f339c98a178f3c1e545622206b40986a4c3307fe39f70ccd3d9df9a9e425/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88b49a3b9ff31e19998750c38e030fc7bb937398b1f78cfa599aaef92d693144", size = 20728 },
+    { url = "https://files.pythonhosted.org/packages/1a/03/8496a1a78308456dbd50b23a385c69b41f2e9661c67ea1329849a598a8f9/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfad01eed2c2e0c01fd0ecd2ef42c492f7f93902e39a42fc9ee1692961443a29", size = 20826 },
+    { url = "https://files.pythonhosted.org/packages/e6/cf/0a490a4bd363048c3022f2f475c8c05582179bb179defcee4766fb3dcc18/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1225beacc926f536dc82e45f8a4d68502949dc67eea90eab715dea3a21c1b5f0", size = 21843 },
+    { url = "https://files.pythonhosted.org/packages/19/a3/34187a78613920dfd3cdf68ef6ce5e99c4f3417f035694074beb8848cd77/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3169b1eefae027567d1ce6ee7cae382c57fe26e82775f460f0b2778beaad66c0", size = 21219 },
+    { url = "https://files.pythonhosted.org/packages/17/d8/5811082f85bb88410ad7e452263af048d685669bbbfb7b595e8689152498/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:eb7972a85c54febfb25b5c4b4f3af4dcc731994c7da0d8a0b4a6eb0640e1d178", size = 20946 },
+    { url = "https://files.pythonhosted.org/packages/7c/31/bd635fb5989440d9365c5e3c47556cfea121c7803f5034ac843e8f37c2f2/MarkupSafe-3.0.2-cp39-cp39-win32.whl", hash = "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f", size = 15063 },
+    { url = "https://files.pythonhosted.org/packages/b3/73/085399401383ce949f727afec55ec3abd76648d04b9f22e1c0e99cb4bec3/MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a", size = 15506 },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/03/a2ecab526543b152300717cf232bb4bb8605b6edb946c845016fa9c9c9fd/mdit_py_plugins-0.4.2.tar.gz", hash = "sha256:5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5", size = 43542 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl", hash = "sha256:0c673c3f889399a33b95e88d2f0d111b4447bdfea7f237dab2d488f459835636", size = 55316 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
+name = "mypy"
+version = "1.14.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "mypy-extensions", marker = "python_full_version < '3.9'" },
+    { name = "tomli", marker = "python_full_version < '3.9'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/eb/2c92d8ea1e684440f54fa49ac5d9a5f19967b7b472a281f419e69a8d228e/mypy-1.14.1.tar.gz", hash = "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6", size = 3216051 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/7a/87ae2adb31d68402da6da1e5f30c07ea6063e9f09b5e7cfc9dfa44075e74/mypy-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:52686e37cf13d559f668aa398dd7ddf1f92c5d613e4f8cb262be2fb4fedb0fcb", size = 11211002 },
+    { url = "https://files.pythonhosted.org/packages/e1/23/eada4c38608b444618a132be0d199b280049ded278b24cbb9d3fc59658e4/mypy-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1fb545ca340537d4b45d3eecdb3def05e913299ca72c290326be19b3804b39c0", size = 10358400 },
+    { url = "https://files.pythonhosted.org/packages/43/c9/d6785c6f66241c62fd2992b05057f404237deaad1566545e9f144ced07f5/mypy-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90716d8b2d1f4cd503309788e51366f07c56635a3309b0f6a32547eaaa36a64d", size = 12095172 },
+    { url = "https://files.pythonhosted.org/packages/c3/62/daa7e787770c83c52ce2aaf1a111eae5893de9e004743f51bfcad9e487ec/mypy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ae753f5c9fef278bcf12e1a564351764f2a6da579d4a81347e1d5a15819997b", size = 12828732 },
+    { url = "https://files.pythonhosted.org/packages/1b/a2/5fb18318a3637f29f16f4e41340b795da14f4751ef4f51c99ff39ab62e52/mypy-1.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0fe0f5feaafcb04505bcf439e991c6d8f1bf8b15f12b05feeed96e9e7bf1427", size = 13012197 },
+    { url = "https://files.pythonhosted.org/packages/28/99/e153ce39105d164b5f02c06c35c7ba958aaff50a2babba7d080988b03fe7/mypy-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:7d54bd85b925e501c555a3227f3ec0cfc54ee8b6930bd6141ec872d1c572f81f", size = 9780836 },
+    { url = "https://files.pythonhosted.org/packages/da/11/a9422850fd506edbcdc7f6090682ecceaf1f87b9dd847f9df79942da8506/mypy-1.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f995e511de847791c3b11ed90084a7a0aafdc074ab88c5a9711622fe4751138c", size = 11120432 },
+    { url = "https://files.pythonhosted.org/packages/b6/9e/47e450fd39078d9c02d620545b2cb37993a8a8bdf7db3652ace2f80521ca/mypy-1.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d64169ec3b8461311f8ce2fd2eb5d33e2d0f2c7b49116259c51d0d96edee48d1", size = 10279515 },
+    { url = "https://files.pythonhosted.org/packages/01/b5/6c8d33bd0f851a7692a8bfe4ee75eb82b6983a3cf39e5e32a5d2a723f0c1/mypy-1.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba24549de7b89b6381b91fbc068d798192b1b5201987070319889e93038967a8", size = 12025791 },
+    { url = "https://files.pythonhosted.org/packages/f0/4c/e10e2c46ea37cab5c471d0ddaaa9a434dc1d28650078ac1b56c2d7b9b2e4/mypy-1.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:183cf0a45457d28ff9d758730cd0210419ac27d4d3f285beda038c9083363b1f", size = 12749203 },
+    { url = "https://files.pythonhosted.org/packages/88/55/beacb0c69beab2153a0f57671ec07861d27d735a0faff135a494cd4f5020/mypy-1.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f2a0ecc86378f45347f586e4163d1769dd81c5a223d577fe351f26b179e148b1", size = 12885900 },
+    { url = "https://files.pythonhosted.org/packages/a2/75/8c93ff7f315c4d086a2dfcde02f713004357d70a163eddb6c56a6a5eff40/mypy-1.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:ad3301ebebec9e8ee7135d8e3109ca76c23752bac1e717bc84cd3836b4bf3eae", size = 9777869 },
+    { url = "https://files.pythonhosted.org/packages/43/1b/b38c079609bb4627905b74fc6a49849835acf68547ac33d8ceb707de5f52/mypy-1.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30ff5ef8519bbc2e18b3b54521ec319513a26f1bba19a7582e7b1f58a6e69f14", size = 11266668 },
+    { url = "https://files.pythonhosted.org/packages/6b/75/2ed0d2964c1ffc9971c729f7a544e9cd34b2cdabbe2d11afd148d7838aa2/mypy-1.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cb9f255c18052343c70234907e2e532bc7e55a62565d64536dbc7706a20b78b9", size = 10254060 },
+    { url = "https://files.pythonhosted.org/packages/a1/5f/7b8051552d4da3c51bbe8fcafffd76a6823779101a2b198d80886cd8f08e/mypy-1.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b4e3413e0bddea671012b063e27591b953d653209e7a4fa5e48759cda77ca11", size = 11933167 },
+    { url = "https://files.pythonhosted.org/packages/04/90/f53971d3ac39d8b68bbaab9a4c6c58c8caa4d5fd3d587d16f5927eeeabe1/mypy-1.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:553c293b1fbdebb6c3c4030589dab9fafb6dfa768995a453d8a5d3b23784af2e", size = 12864341 },
+    { url = "https://files.pythonhosted.org/packages/03/d2/8bc0aeaaf2e88c977db41583559319f1821c069e943ada2701e86d0430b7/mypy-1.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fad79bfe3b65fe6a1efaed97b445c3d37f7be9fdc348bdb2d7cac75579607c89", size = 12972991 },
+    { url = "https://files.pythonhosted.org/packages/6f/17/07815114b903b49b0f2cf7499f1c130e5aa459411596668267535fe9243c/mypy-1.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:8fa2220e54d2946e94ab6dbb3ba0a992795bd68b16dc852db33028df2b00191b", size = 9879016 },
+    { url = "https://files.pythonhosted.org/packages/39/02/1817328c1372be57c16148ce7d2bfcfa4a796bedaed897381b1aad9b267c/mypy-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7084fb8f1128c76cd9cf68fe5971b37072598e7c31b2f9f95586b65c741a9d31", size = 11143050 },
+    { url = "https://files.pythonhosted.org/packages/b9/07/99db9a95ece5e58eee1dd87ca456a7e7b5ced6798fd78182c59c35a7587b/mypy-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8f845a00b4f420f693f870eaee5f3e2692fa84cc8514496114649cfa8fd5e2c6", size = 10321087 },
+    { url = "https://files.pythonhosted.org/packages/9a/eb/85ea6086227b84bce79b3baf7f465b4732e0785830726ce4a51528173b71/mypy-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44bf464499f0e3a2d14d58b54674dee25c031703b2ffc35064bd0df2e0fac319", size = 12066766 },
+    { url = "https://files.pythonhosted.org/packages/4b/bb/f01bebf76811475d66359c259eabe40766d2f8ac8b8250d4e224bb6df379/mypy-1.14.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99f27732c0b7dc847adb21c9d47ce57eb48fa33a17bc6d7d5c5e9f9e7ae5bac", size = 12787111 },
+    { url = "https://files.pythonhosted.org/packages/2f/c9/84837ff891edcb6dcc3c27d85ea52aab0c4a34740ff5f0ccc0eb87c56139/mypy-1.14.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:bce23c7377b43602baa0bd22ea3265c49b9ff0b76eb315d6c34721af4cdf1d9b", size = 12974331 },
+    { url = "https://files.pythonhosted.org/packages/84/5f/901e18464e6a13f8949b4909535be3fa7f823291b8ab4e4b36cfe57d6769/mypy-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:8edc07eeade7ebc771ff9cf6b211b9a7d93687ff892150cb5692e4f4272b0837", size = 9763210 },
+    { url = "https://files.pythonhosted.org/packages/ca/1f/186d133ae2514633f8558e78cd658070ba686c0e9275c5a5c24a1e1f0d67/mypy-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3888a1816d69f7ab92092f785a462944b3ca16d7c470d564165fe703b0970c35", size = 11200493 },
+    { url = "https://files.pythonhosted.org/packages/af/fc/4842485d034e38a4646cccd1369f6b1ccd7bc86989c52770d75d719a9941/mypy-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46c756a444117c43ee984bd055db99e498bc613a70bbbc120272bd13ca579fbc", size = 10357702 },
+    { url = "https://files.pythonhosted.org/packages/b4/e6/457b83f2d701e23869cfec013a48a12638f75b9d37612a9ddf99072c1051/mypy-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27fc248022907e72abfd8e22ab1f10e903915ff69961174784a3900a8cba9ad9", size = 12091104 },
+    { url = "https://files.pythonhosted.org/packages/f1/bf/76a569158db678fee59f4fd30b8e7a0d75bcbaeef49edd882a0d63af6d66/mypy-1.14.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:499d6a72fb7e5de92218db961f1a66d5f11783f9ae549d214617edab5d4dbdbb", size = 12830167 },
+    { url = "https://files.pythonhosted.org/packages/43/bc/0bc6b694b3103de9fed61867f1c8bd33336b913d16831431e7cb48ef1c92/mypy-1.14.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:57961db9795eb566dc1d1b4e9139ebc4c6b0cb6e7254ecde69d1552bf7613f60", size = 13013834 },
+    { url = "https://files.pythonhosted.org/packages/b0/79/5f5ec47849b6df1e6943d5fd8e6632fbfc04b4fd4acfa5a5a9535d11b4e2/mypy-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:07ba89fdcc9451f2ebb02853deb6aaaa3d2239a236669a63ab3801bbf923ef5c", size = 9781231 },
+    { url = "https://files.pythonhosted.org/packages/a0/b5/32dd67b69a16d088e533962e5044e51004176a9952419de0370cdaead0f8/mypy-1.14.1-py3-none-any.whl", hash = "sha256:b66a60cc4073aeb8ae00057f9c1f64d49e90f918fbcef9a977eb121da8b8f1d1", size = 2752905 },
+]
+
+[[package]]
+name = "mypy"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "mypy-extensions", marker = "python_full_version >= '3.9'" },
+    { name = "tomli", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/43/d5e49a86afa64bd3839ea0d5b9c7103487007d728e1293f52525d6d5486a/mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43", size = 3239717 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/f8/65a7ce8d0e09b6329ad0c8d40330d100ea343bd4dd04c4f8ae26462d0a17/mypy-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:979e4e1a006511dacf628e36fadfecbcc0160a8af6ca7dad2f5025529e082c13", size = 10738433 },
+    { url = "https://files.pythonhosted.org/packages/b4/95/9c0ecb8eacfe048583706249439ff52105b3f552ea9c4024166c03224270/mypy-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c4bb0e1bd29f7d34efcccd71cf733580191e9a264a2202b0239da95984c5b559", size = 9861472 },
+    { url = "https://files.pythonhosted.org/packages/84/09/9ec95e982e282e20c0d5407bc65031dfd0f0f8ecc66b69538296e06fcbee/mypy-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be68172e9fd9ad8fb876c6389f16d1c1b5f100ffa779f77b1fb2176fcc9ab95b", size = 11611424 },
+    { url = "https://files.pythonhosted.org/packages/78/13/f7d14e55865036a1e6a0a69580c240f43bc1f37407fe9235c0d4ef25ffb0/mypy-1.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7be1e46525adfa0d97681432ee9fcd61a3964c2446795714699a998d193f1a3", size = 12365450 },
+    { url = "https://files.pythonhosted.org/packages/48/e1/301a73852d40c241e915ac6d7bcd7fedd47d519246db2d7b86b9d7e7a0cb/mypy-1.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2e2c2e6d3593f6451b18588848e66260ff62ccca522dd231cd4dd59b0160668b", size = 12551765 },
+    { url = "https://files.pythonhosted.org/packages/77/ba/c37bc323ae5fe7f3f15a28e06ab012cd0b7552886118943e90b15af31195/mypy-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:6983aae8b2f653e098edb77f893f7b6aca69f6cffb19b2cc7443f23cce5f4828", size = 9274701 },
+    { url = "https://files.pythonhosted.org/packages/03/bc/f6339726c627bd7ca1ce0fa56c9ae2d0144604a319e0e339bdadafbbb599/mypy-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2922d42e16d6de288022e5ca321cd0618b238cfc5570e0263e5ba0a77dbef56f", size = 10662338 },
+    { url = "https://files.pythonhosted.org/packages/e2/90/8dcf506ca1a09b0d17555cc00cd69aee402c203911410136cd716559efe7/mypy-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ee2d57e01a7c35de00f4634ba1bbf015185b219e4dc5909e281016df43f5ee5", size = 9787540 },
+    { url = "https://files.pythonhosted.org/packages/05/05/a10f9479681e5da09ef2f9426f650d7b550d4bafbef683b69aad1ba87457/mypy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973500e0774b85d9689715feeffcc980193086551110fd678ebe1f4342fb7c5e", size = 11538051 },
+    { url = "https://files.pythonhosted.org/packages/e9/9a/1f7d18b30edd57441a6411fcbc0c6869448d1a4bacbaee60656ac0fc29c8/mypy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a95fb17c13e29d2d5195869262f8125dfdb5c134dc8d9a9d0aecf7525b10c2c", size = 12286751 },
+    { url = "https://files.pythonhosted.org/packages/72/af/19ff499b6f1dafcaf56f9881f7a965ac2f474f69f6f618b5175b044299f5/mypy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1905f494bfd7d85a23a88c5d97840888a7bd516545fc5aaedff0267e0bb54e2f", size = 12421783 },
+    { url = "https://files.pythonhosted.org/packages/96/39/11b57431a1f686c1aed54bf794870efe0f6aeca11aca281a0bd87a5ad42c/mypy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c9817fa23833ff189db061e6d2eff49b2f3b6ed9856b4a0a73046e41932d744f", size = 9265618 },
+    { url = "https://files.pythonhosted.org/packages/98/3a/03c74331c5eb8bd025734e04c9840532226775c47a2c39b56a0c8d4f128d/mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd", size = 10793981 },
+    { url = "https://files.pythonhosted.org/packages/f0/1a/41759b18f2cfd568848a37c89030aeb03534411eef981df621d8fad08a1d/mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f", size = 9749175 },
+    { url = "https://files.pythonhosted.org/packages/12/7e/873481abf1ef112c582db832740f4c11b2bfa510e829d6da29b0ab8c3f9c/mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464", size = 11455675 },
+    { url = "https://files.pythonhosted.org/packages/b3/d0/92ae4cde706923a2d3f2d6c39629134063ff64b9dedca9c1388363da072d/mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee", size = 12410020 },
+    { url = "https://files.pythonhosted.org/packages/46/8b/df49974b337cce35f828ba6fda228152d6db45fed4c86ba56ffe442434fd/mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e", size = 12498582 },
+    { url = "https://files.pythonhosted.org/packages/13/50/da5203fcf6c53044a0b699939f31075c45ae8a4cadf538a9069b165c1050/mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22", size = 9366614 },
+    { url = "https://files.pythonhosted.org/packages/5a/fa/79cf41a55b682794abe71372151dbbf856e3008f6767057229e6649d294a/mypy-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e601a7fa172c2131bff456bb3ee08a88360760d0d2f8cbd7a75a65497e2df078", size = 10737129 },
+    { url = "https://files.pythonhosted.org/packages/d3/33/dd8feb2597d648de29e3da0a8bf4e1afbda472964d2a4a0052203a6f3594/mypy-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:712e962a6357634fef20412699a3655c610110e01cdaa6180acec7fc9f8513ba", size = 9856335 },
+    { url = "https://files.pythonhosted.org/packages/e4/b5/74508959c1b06b96674b364ffeb7ae5802646b32929b7701fc6b18447592/mypy-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f95579473af29ab73a10bada2f9722856792a36ec5af5399b653aa28360290a5", size = 11611935 },
+    { url = "https://files.pythonhosted.org/packages/6c/53/da61b9d9973efcd6507183fdad96606996191657fe79701b2c818714d573/mypy-1.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f8722560a14cde92fdb1e31597760dc35f9f5524cce17836c0d22841830fd5b", size = 12365827 },
+    { url = "https://files.pythonhosted.org/packages/c1/72/965bd9ee89540c79a25778cc080c7e6ef40aa1eeac4d52cec7eae6eb5228/mypy-1.15.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1fbb8da62dc352133d7d7ca90ed2fb0e9d42bb1a32724c287d3c76c58cbaa9c2", size = 12541924 },
+    { url = "https://files.pythonhosted.org/packages/46/d0/f41645c2eb263e6c77ada7d76f894c580c9ddb20d77f0c24d34273a4dab2/mypy-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:d10d994b41fb3497719bbf866f227b3489048ea4bbbb5015357db306249f7980", size = 9271176 },
+    { url = "https://files.pythonhosted.org/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e", size = 2221777 },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
+]
+
+[[package]]
+name = "myst-parser"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/64/e2f13dac02f599980798c01156393b781aec983b52a6e4057ee58f07c43a/myst_parser-3.0.1.tar.gz", hash = "sha256:88f0cb406cb363b077d176b51c476f62d60604d68a8dcdf4832e080441301a87", size = 92392 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/de/21aa8394f16add8f7427f0a1326ccd2b3a2a8a3245c9252bc5ac034c6155/myst_parser-3.0.1-py3-none-any.whl", hash = "sha256:6457aaa33a5d474aca678b8ead9b3dc298e89c68e67012e73146ea6fd54babf1", size = 83163 },
+]
+
+[[package]]
+name = "packaging"
+version = "22.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/f7/c240d7654ddd2d2f3f328d8468d4f1f876865f6b9038b146bec0a6737c65/packaging-22.0.tar.gz", hash = "sha256:2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3", size = 125371 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/7b/42582927d281d7cb035609cd3a543ffac89b74f3f4ee8e1c50914bcb57eb/packaging-22.0-py3-none-any.whl", hash = "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3", size = 42619 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.50"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/e1/bd15cb8ffdcfeeb2bdc215de3c3cffca11408d829e4b8416dcfe71ba8854/prompt_toolkit-3.0.50.tar.gz", hash = "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab", size = 429087 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/ea/d836f008d33151c7a1f62caf3d8dd782e4d15f6a43897f64480c2b8de2ad/prompt_toolkit-3.0.50-py3-none-any.whl", hash = "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198", size = 387816 },
+]
+
+[[package]]
+name = "pyenchant"
+version = "3.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/a3/86763b6350727ca81c8fcc5bb5bccee416e902e0085dc7a902c81233717e/pyenchant-3.2.2.tar.gz", hash = "sha256:1cf830c6614362a78aab78d50eaf7c6c93831369c52e1bb64ffae1df0341e637", size = 49580 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/4c/a741dddab6ad96f257d90cb4d23067ffadac526c9cab3a99ca6ce3c05477/pyenchant-3.2.2-py3-none-any.whl", hash = "sha256:5facc821ece957208a81423af7d6ec7810dad29697cb0d77aae81e4e11c8e5a6", size = 55660 },
+    { url = "https://files.pythonhosted.org/packages/01/44/1e9a273d230abf5c961750a75e42b449adfb61eb446f80b6523955d2a4a2/pyenchant-3.2.2-py3-none-win32.whl", hash = "sha256:5a636832987eaf26efe971968f4d1b78e81f62bca2bde0a9da210c7de43c3bce", size = 11884084 },
+    { url = "https://files.pythonhosted.org/packages/49/96/2087455de16b08e86fa7ce70b53ddac5fcc040c899d9ebad507a0efec52d/pyenchant-3.2.2-py3-none-win_amd64.whl", hash = "sha256:6153f521852e23a5add923dbacfbf4bebbb8d70c4e4bad609a8e0f9faeb915d1", size = 11890882 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216 },
+]
+
+[[package]]
+name = "pytest"
+version = "7.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287 },
+]
+
+[[package]]
+name = "pytest-click"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/ec/bca3cd29ba2b025ae41666b851f6ff05fb77cb4c13719baaeda6a757772a/pytest_click-1.1.0.tar.gz", hash = "sha256:fdd9f6721f877dda021e7c5dc73e70aecd37e5ed23ec6820f8a7b3fd7b4f8d30", size = 5054 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/1a/eb53371999b94b3c995c00117f3a232dbf6f56c7152a52cf3e3777e7d49d/pytest_click-1.1.0-py3-none-any.whl", hash = "sha256:eade4742c2f02c345e78a32534a43e8db04acf98d415090539dacc880b7cd0e9", size = 4110 },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.9'" },
+    { name = "pytest", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/67/00efc8d11b630c56f15f4ad9c7f9223f1e5ec275aaae3fa9118c6a223ad2/pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857", size = 63042 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/3a/af5b4fa5961d9a1e6237b530eb87dd04aea6eb83da09d2a4073d81b54ccf/pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652", size = 21990 },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "coverage", version = "7.8.0", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.9'" },
+    { name = "pytest", marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/8c/039a7793f23f5cb666c834da9e944123f498ccc0753bed5fbfb2e2c11f87/pytest_cov-6.1.0.tar.gz", hash = "sha256:ec55e828c66755e5b74a21bd7cc03c303a9f928389c0563e50ba454a6dbe71db", size = 66651 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/c5/8d6ffe9fc8f7f57b3662156ae8a34f2b8e7a754c73b48e689ce43145e98c/pytest_cov-6.1.0-py3-none-any.whl", hash = "sha256:cd7e1d54981d5185ef2b8d64b50172ce97e6f357e6df5cb103e828c7f993e201", size = 23743 },
+]
+
+[[package]]
+name = "pytest-explicit"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/9f/ddd55b6318bc8867a746cb552709e40b80f1f6e67a2dcc3b9cd425834697/pytest-explicit-1.0.1.tar.gz", hash = "sha256:d7ebc0335ce11cb34fc77212744996549cf35204cf739fb8fbc9be16e3d88ebf", size = 4288 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/6d/94fd71f72b8715d48fe3f6b91626ea41a18ea25daa163c270f0f511fbb1d/pytest_explicit-1.0.1-py3-none-any.whl", hash = "sha256:3e2279c1097c0379799bc2b99f9ff1fd12c36ca5b545a241e2ae2c48eda26344", size = 4406 },
+]
+
+[[package]]
+name = "pytest-object-getter"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/fe/d80930717c5e71028c9fd245cbf647da2062994d49d627c0b3147309abf6/pytest_object_getter-1.0.2.tar.gz", hash = "sha256:482c6e407d3e67a0de977437434f923a5fcd02503663c19bfccda9985b9d0649", size = 28027 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/73/46e99f3099f325310261482f9342c9cd719b08c78e23e83615cf464fa20f/pytest_object_getter-1.0.2-py3-none-any.whl", hash = "sha256:1ca9f06f6827ceeb1621e49e9095401130ae051b45beb516882ca1b4af598dd7", size = 19350 },
+]
+
+[[package]]
+name = "pytest-requests-futures"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/f9/d82bc18a3ac9eff6c5466dd194004906cabf228834b277f7c10a3f796893/pytest_requests_futures-0.9.0.tar.gz", hash = "sha256:e898345c039d1ada13dd39ab06d934801d37fe5e811741cab9fd2056b8984f77", size = 25131 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/ca/2fd907d1f1e5b1bbb781a6f61b4e4dd949e8ec976e308875a656d2589957/pytest_requests_futures-0.9.0-py3-none-any.whl", hash = "sha256:49f9f1a5aa63ceaf55f71fd5fa1e36b824184adcbbb3eaf26163a1f5735c00a9", size = 17179 },
+]
+
+[[package]]
+name = "pytest-run-subprocess"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/91/090c61d00dcbf4a422bbe86408a0fef57e659b13f4f6014cace2ff6027b4/pytest_run_subprocess-0.9.0.tar.gz", hash = "sha256:98197a7cf0af1f1e673d460ba3f5bb68c895c2d64e35712c6cd0cbe8da4dd6db", size = 25113 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/c6/d7af389d8f9fc2f8a8baa68be9e79fb919fb0ba0d71d5989d6a0ae13a6f3/pytest_run_subprocess-0.9.0-py3-none-any.whl", hash = "sha256:f31e80ee38f287334a875dee2e096e62667f1d37bc3ef4da2de5a9e4d6754cf3", size = 16994 },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/c4/3c310a19bc1f1e9ef50075582652673ef2bfc8cd62afef9585683821902f/pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d", size = 84060 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/82/1d96bf03ee4c0fdc3c0cbe61470070e659ca78dc0086fb88b66c185e2449/pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7", size = 46108 },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051 },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199 },
+    { url = "https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf", size = 171758 },
+    { url = "https://files.pythonhosted.org/packages/49/ee/14c54df452143b9ee9f0f29074d7ca5516a36edb0b4cc40c3f280131656f/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237", size = 718463 },
+    { url = "https://files.pythonhosted.org/packages/4d/61/de363a97476e766574650d742205be468921a7b532aa2499fcd886b62530/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b", size = 719280 },
+    { url = "https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed", size = 751239 },
+    { url = "https://files.pythonhosted.org/packages/b7/33/5504b3a9a4464893c32f118a9cc045190a91637b119a9c881da1cf6b7a72/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180", size = 695802 },
+    { url = "https://files.pythonhosted.org/packages/5c/20/8347dcabd41ef3a3cdc4f7b7a2aff3d06598c8779faa189cdbf878b626a4/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68", size = 720527 },
+    { url = "https://files.pythonhosted.org/packages/be/aa/5afe99233fb360d0ff37377145a949ae258aaab831bde4792b32650a4378/PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99", size = 144052 },
+    { url = "https://files.pythonhosted.org/packages/b5/84/0fa4b06f6d6c958d207620fc60005e241ecedceee58931bb20138e1e5776/PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e", size = 161774 },
+    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612 },
+    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040 },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829 },
+    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167 },
+    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952 },
+    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301 },
+    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638 },
+    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850 },
+    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980 },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
+    { url = "https://files.pythonhosted.org/packages/74/d9/323a59d506f12f498c2097488d80d16f4cf965cee1791eab58b56b19f47a/PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a", size = 183218 },
+    { url = "https://files.pythonhosted.org/packages/74/cc/20c34d00f04d785f2028737e2e2a8254e1425102e730fee1d6396f832577/PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5", size = 728067 },
+    { url = "https://files.pythonhosted.org/packages/20/52/551c69ca1501d21c0de51ddafa8c23a0191ef296ff098e98358f69080577/PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d", size = 757812 },
+    { url = "https://files.pythonhosted.org/packages/fd/7f/2c3697bba5d4aa5cc2afe81826d73dfae5f049458e44732c7a0938baa673/PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083", size = 746531 },
+    { url = "https://files.pythonhosted.org/packages/8c/ab/6226d3df99900e580091bb44258fde77a8433511a86883bd4681ea19a858/PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706", size = 800820 },
+    { url = "https://files.pythonhosted.org/packages/a0/99/a9eb0f3e710c06c5d922026f6736e920d431812ace24aae38228d0d64b04/PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a", size = 145514 },
+    { url = "https://files.pythonhosted.org/packages/75/8a/ee831ad5fafa4431099aa4e078d4c8efd43cd5e48fbc774641d233b683a9/PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff", size = 162702 },
+    { url = "https://files.pythonhosted.org/packages/65/d8/b7a1db13636d7fb7d4ff431593c510c8b8fca920ade06ca8ef20015493c5/PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d", size = 184777 },
+    { url = "https://files.pythonhosted.org/packages/0a/02/6ec546cd45143fdf9840b2c6be8d875116a64076218b61d68e12548e5839/PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f", size = 172318 },
+    { url = "https://files.pythonhosted.org/packages/0e/9a/8cc68be846c972bda34f6c2a93abb644fb2476f4dcc924d52175786932c9/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290", size = 720891 },
+    { url = "https://files.pythonhosted.org/packages/e9/6c/6e1b7f40181bc4805e2e07f4abc10a88ce4648e7e95ff1abe4ae4014a9b2/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12", size = 722614 },
+    { url = "https://files.pythonhosted.org/packages/3d/32/e7bd8535d22ea2874cef6a81021ba019474ace0d13a4819c2a4bce79bd6a/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19", size = 737360 },
+    { url = "https://files.pythonhosted.org/packages/d7/12/7322c1e30b9be969670b672573d45479edef72c9a0deac3bb2868f5d7469/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e", size = 699006 },
+    { url = "https://files.pythonhosted.org/packages/82/72/04fcad41ca56491995076630c3ec1e834be241664c0c09a64c9a2589b507/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725", size = 723577 },
+    { url = "https://files.pythonhosted.org/packages/ed/5e/46168b1f2757f1fcd442bc3029cd8767d88a98c9c05770d8b420948743bb/PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631", size = 144593 },
+    { url = "https://files.pythonhosted.org/packages/19/87/5124b1c1f2412bb95c59ec481eaf936cd32f0fe2a7b16b97b81c4c017a6a/PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8", size = 162312 },
+]
+
+[[package]]
+name = "questionary"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/c6/a8dbf1edcbc236d93348f6e7c437cf09c7356dd27119fcc3be9d70c93bb1/questionary-1.10.0.tar.gz", hash = "sha256:600d3aefecce26d48d97eee936fdb66e4bc27f934c3ab6dd1e292c4f43946d90", size = 23530 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/00/151ff8314078efa3087c23b4b7c473f08f601dff7c62bfb894dd462e0fc9/questionary-1.10.0-py3-none-any.whl", hash = "sha256:fecfcc8cca110fda9d561cb83f1e97ecbb93c613ff857f655818839dac74ce90", size = 31443 },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "urllib3", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
+]
+
+[[package]]
+name = "requests-futures"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/f8/175b823241536ba09da033850d66194c372c65c38804847ac9cef0239542/requests_futures-1.0.2.tar.gz", hash = "sha256:6b7eb57940336e800faebc3dab506360edec9478f7b22dc570858ad3aa7458da", size = 10356 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/23/7c1096731c15c83826cb0dd42078b561a838aed44c36f370aeb815168106/requests_futures-1.0.2-py2.py3-none-any.whl", hash = "sha256:a3534af7c2bf670cd7aa730716e9e7d4386497554f87792be7514063b8912897", size = 7671 },
+]
+
+[[package]]
+name = "rich"
+version = "13.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303 },
+]
+
+[[package]]
+name = "snowballstemmer"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/7b/af302bebf22c749c56c9c3e8ae13190b5b5db37a33d9068652e8f73b7089/snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1", size = 86699 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a", size = 93002 },
+]
+
+[[package]]
+name = "software-patterns"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/15/106c8e29433b535c1be3132458f696433ea4d74335d6abfa46a95dd930f4/software_patterns-1.3.0.tar.gz", hash = "sha256:882f5366ded3d7daff9376afbc2da00b0eedc4ca64b849d775428e43856630c8", size = 26879 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/4e/c0b6f261d8dda36e9f91c2320e56d0356926edc628eb6fe270cd94132b31/software_patterns-1.3.0-py3-none-any.whl", hash = "sha256:5d303110cd9cba899df0aa0ffd2835d33395fffef2607597058db8e2ea53dec7", size = 23513 },
+]
+
+[[package]]
+name = "sphinx"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alabaster", version = "0.7.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "alabaster", version = "0.7.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "importlib-metadata", version = "8.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp", version = "1.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "sphinxcontrib-applehelp", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "sphinxcontrib-devhelp", version = "1.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "sphinxcontrib-devhelp", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "sphinxcontrib-htmlhelp", version = "2.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "sphinxcontrib-htmlhelp", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp", version = "1.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "sphinxcontrib-qthelp", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "sphinxcontrib-serializinghtml", version = "1.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "sphinxcontrib-serializinghtml", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/6d/392defcc95ca48daf62aecb89550143e97a4651275e62a3d7755efe35a3a/Sphinx-6.2.1.tar.gz", hash = "sha256:6d56a34697bb749ffa0152feafc4b19836c755d90a7c59b72bc7dfd371b9cc6b", size = 6681092 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/d8/45ba6097c39ba44d9f0e1462fb232e13ca4ddb5aea93a385dcfa964687da/sphinx-6.2.1-py3-none-any.whl", hash = "sha256:97787ff1fa3256a3eef9eda523a63dbf299f7b47e053cfcf684a1c2a8380c912", size = 3024615 },
+]
+
+[[package]]
+name = "sphinx-autobuild"
+version = "2021.3.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "livereload" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/a5/2ed1b81e398bc14533743be41bf0ceaa49d671675f131c4d9ce74897c9c1/sphinx-autobuild-2021.3.14.tar.gz", hash = "sha256:de1ca3b66e271d2b5b5140c35034c89e47f263f2cd5db302c9217065f7443f05", size = 206402 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/7d/8fb7557b6c9298d2bcda57f4d070de443c6355dfb475582378e2aa16a02c/sphinx_autobuild-2021.3.14-py3-none-any.whl", hash = "sha256:8fe8cbfdb75db04475232f05187c776f46f6e9e04cacf1e49ce81bdac649ccac", size = 9881 },
+]
+
+[[package]]
+name = "sphinx-autodoc-typehints"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/30/9764a2c735c655c3065f32072fb3d8c6fd5dda8df294d4e9f05670d60e31/sphinx_autodoc_typehints-1.23.0.tar.gz", hash = "sha256:5d44e2996633cdada499b6d27a496ddf9dbc95dd1f0f09f7b37940249e61f6e9", size = 35945 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/be/792b64ddacfcff362062077689ce37eb9750b9924fc0a14f623fa71ffaf6/sphinx_autodoc_typehints-1.23.0-py3-none-any.whl", hash = "sha256:ac099057e66b09e51b698058ba7dd76e57e1fe696cd91b54e121d3dad188f91d", size = 17896 },
+]
+
+[[package]]
+name = "sphinx-inline-tabs"
+version = "2023.4.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f5/f8a2be63ed7be9f91a4c2bea0e25bcb56aa4c5cc37ec4d8ead8065f926b1/sphinx_inline_tabs-2023.4.21.tar.gz", hash = "sha256:5df2f13f602c158f3f5f6c509e008aeada199a8c76d97ba3aa2822206683bebc", size = 42664 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/60/1e4c9017d722b9c7731abc11f39ac8b083b479fbcefe12015b57e457a296/sphinx_inline_tabs-2023.4.21-py3-none-any.whl", hash = "sha256:06809ac613f7c48ddd6e2fa588413e3fe92cff2397b56e2ccf0b0218f9ef6a78", size = 6850 },
+]
+
+[[package]]
+name = "sphinx-rtd-theme"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/cd/1eb84d8b11ecac97a85c42199bb5566eee0bb946b27138f28cbea1d729e7/sphinx_rtd_theme-0.5.0.tar.gz", hash = "sha256:22c795ba2832a169ca301cd0a083f7a434e09c538c70beb42782c073651b707d", size = 2772707 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/86/1addf25a238bbd8466bb099f23d9a9f13494b22b37b44f6c41a778b8730f/sphinx_rtd_theme-0.5.0-py2.py3-none-any.whl", hash = "sha256:373413d0f82425aaa28fb288009bf0d0964711d347763af2f1b65cafcb028c82", size = 10765978 },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/df/45e827f4d7e7fcc84e853bcef1d836effd762d63ccb86f43ede4e98b478c/sphinxcontrib-applehelp-1.0.4.tar.gz", hash = "sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e", size = 24766 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/c1/5e2cafbd03105ce50d8500f9b4e8a6e8d02e22d0475b574c3b3e9451a15f/sphinxcontrib_applehelp-1.0.4-py3-none-any.whl", hash = "sha256:29d341f67fb0f6f586b23ad80e072c8e6ad0b48417db2bde114a4c9746feb228", size = 120601 },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300 },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/33/dc28393f16385f722c893cb55539c641c9aaec8d1bc1c15b69ce0ac2dbb3/sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4", size = 17398 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/09/5de5ed43a521387f18bdf5f5af31d099605c992fd25372b2b9b825ce48ee/sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e", size = 84690 },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530 },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/47/64cff68ea3aa450c373301e5bebfbb9fce0a3e70aca245fcadd4af06cd75/sphinxcontrib-htmlhelp-2.0.1.tar.gz", hash = "sha256:0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff", size = 27967 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/ee/a1f5e39046cbb5f8bc8fba87d1ddf1c6643fbc9194e58d26e606de4b9074/sphinxcontrib_htmlhelp-2.0.1-py3-none-any.whl", hash = "sha256:c38cb46dccf316c79de6e5515e1770414b797162b23cd3d06e67020e1d2a6903", size = 99833 },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705 },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071 },
+]
+
+[[package]]
+name = "sphinxcontrib-mermaid"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/70/3d5664a7260a57b68f0b3ddcb29934b7888cbaf1577163e1db81bb9e42e2/sphinxcontrib-mermaid-0.9.2.tar.gz", hash = "sha256:252ef13dd23164b28f16d8b0205cf184b9d8e2b714a302274d9f59eb708e77af", size = 17909 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/1e/e8b5c7536deba39eac1444c83d404374ed00c3a567445ba122249648a9fc/sphinxcontrib_mermaid-0.9.2-py3-none-any.whl", hash = "sha256:6795a72037ca55e65663d2a2c1a043d636dc3d30d418e56dd6087d1459d98a5d", size = 13453 },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/8e/c4846e59f38a5f2b4a0e3b27af38f2fcf904d4bfd82095bf92de0b114ebd/sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72", size = 21658 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/14/05f9206cf4e9cfca1afb5fd224c7cd434dcc3a433d6d9e4e0264d29c6cdb/sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6", size = 90609 },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743 },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/72/835d6fadb9e5d02304cf39b18f93d227cd93abd3c41ebf58e6853eeb1455/sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952", size = 21019 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/77/5464ec50dd0f1c1037e3c93249b040c8fc8078fdda97530eeb02424b6eea/sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd", size = 94021 },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072 },
+]
+
+[[package]]
+name = "sphinxcontrib-spelling"
+version = "7.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyenchant" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/a5/24a02843204c75690ecca9c1be9b395740b9a6fd72466483d50cc26ee5da/sphinxcontrib-spelling-7.3.3.tar.gz", hash = "sha256:3819d12629d95e0c909224fa40b462a67e0adb321d50283d7fc0d11686c8ac7e", size = 51912 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/3f/ada5ab0b55664feb5217589c80adf92004a1b00aebeb4a995454cb0e2a36/sphinxcontrib_spelling-7.3.3-py3-none-any.whl", hash = "sha256:8809d5dc175f43f00628134a41ef9fec56db9f794f4eab701f9a5a87f8c69bb0", size = 15207 },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154 },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077 },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429 },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067 },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030 },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898 },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894 },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319 },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273 },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310 },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309 },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762 },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453 },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349 },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159 },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243 },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645 },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584 },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+]
+
+[[package]]
+name = "tornado"
+version = "6.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/45/a0daf161f7d6f36c3ea5fc0c2de619746cc3dd4c76402e9db545bd920f63/tornado-6.4.2.tar.gz", hash = "sha256:92bad5b4746e9879fd7bf1eb21dce4e3fc5128d71601f80005afa39237ad620b", size = 501135 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/7e/71f604d8cea1b58f82ba3590290b66da1e72d840aeb37e0d5f7291bd30db/tornado-6.4.2-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e828cce1123e9e44ae2a50a9de3055497ab1d0aeb440c5ac23064d9e44880da1", size = 436299 },
+    { url = "https://files.pythonhosted.org/packages/96/44/87543a3b99016d0bf54fdaab30d24bf0af2e848f1d13d34a3a5380aabe16/tornado-6.4.2-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:072ce12ada169c5b00b7d92a99ba089447ccc993ea2143c9ede887e0937aa803", size = 434253 },
+    { url = "https://files.pythonhosted.org/packages/cb/fb/fdf679b4ce51bcb7210801ef4f11fdac96e9885daa402861751353beea6e/tornado-6.4.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a017d239bd1bb0919f72af256a970624241f070496635784d9bf0db640d3fec", size = 437602 },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/e31aeffffc22b475a64dbeb273026a21b5b566f74dee48742817626c47dc/tornado-6.4.2-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c36e62ce8f63409301537222faffcef7dfc5284f27eec227389f2ad11b09d946", size = 436972 },
+    { url = "https://files.pythonhosted.org/packages/22/55/b78a464de78051a30599ceb6983b01d8f732e6f69bf37b4ed07f642ac0fc/tornado-6.4.2-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bca9eb02196e789c9cb5c3c7c0f04fb447dc2adffd95265b2c7223a8a615ccbf", size = 437173 },
+    { url = "https://files.pythonhosted.org/packages/79/5e/be4fb0d1684eb822c9a62fb18a3e44a06188f78aa466b2ad991d2ee31104/tornado-6.4.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:304463bd0772442ff4d0f5149c6f1c2135a1fae045adf070821c6cdc76980634", size = 437892 },
+    { url = "https://files.pythonhosted.org/packages/f5/33/4f91fdd94ea36e1d796147003b490fe60a0215ac5737b6f9c65e160d4fe0/tornado-6.4.2-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:c82c46813ba483a385ab2a99caeaedf92585a1f90defb5693351fa7e4ea0bf73", size = 437334 },
+    { url = "https://files.pythonhosted.org/packages/2b/ae/c1b22d4524b0e10da2f29a176fb2890386f7bd1f63aacf186444873a88a0/tornado-6.4.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:932d195ca9015956fa502c6b56af9eb06106140d844a335590c1ec7f5277d10c", size = 437261 },
+    { url = "https://files.pythonhosted.org/packages/b5/25/36dbd49ab6d179bcfc4c6c093a51795a4f3bed380543a8242ac3517a1751/tornado-6.4.2-cp38-abi3-win32.whl", hash = "sha256:2876cef82e6c5978fde1e0d5b1f919d756968d5b4282418f3146b79b58556482", size = 438463 },
+    { url = "https://files.pythonhosted.org/packages/61/cc/58b1adeb1bb46228442081e746fcdbc4540905c87e8add7c277540934edb/tornado-6.4.2-cp38-abi3-win_amd64.whl", hash = "sha256:908b71bf3ff37d81073356a5fadcc660eb10c1476ee6e2725588626ce7e5ca38", size = 438907 },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20241206"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/60/47d92293d9bc521cd2301e423a358abfac0ad409b3a1606d8fbae1321961/types_python_dateutil-2.9.0.20241206.tar.gz", hash = "sha256:18f493414c26ffba692a72369fea7a154c502646301ebfe3d56a04b3767284cb", size = 13802 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/b3/ca41df24db5eb99b00d97f89d7674a90cb6b3134c52fb8121b6d8d30f15c/types_python_dateutil-2.9.0.20241206-py3-none-any.whl", hash = "sha256:e248a4bc70a486d3e3ec84d0dc30eec3a5f979d6e7ee4123ae043eedbb987f53", size = 14384 },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20241230"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/f9/4d566925bcf9396136c0a2e5dc7e230ff08d86fa011a69888dd184469d80/types_pyyaml-6.0.12.20241230.tar.gz", hash = "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c", size = 17078 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/c1/48474fbead512b70ccdb4f81ba5eb4a58f69d100ba19f17c92c0c4f50ae6/types_PyYAML-6.0.12.20241230-py3-none-any.whl", hash = "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6", size = 20029 },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250326"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/66/f58e386be67589d5c3c9c0a368600783ac1321b7e6ee213c8f51848dbf0c/types_pyyaml-6.0.12.20250326.tar.gz", hash = "sha256:5e2d86d8706697803f361ba0b8188eef2999e1c372cd4faee4ebb0844b8a4190", size = 17346 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/1e/5609fea65117db83cc060342d4f6810f3cf1d3453b9f81bfe5f03f679633/types_pyyaml-6.0.12.20250326-py3-none-any.whl", hash = "sha256:961871cfbdc1ad8ae3cb6ae3f13007262bcfc168adc513119755a6e4d5d7ed65", size = 20398 },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.27.31"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/d3/f009dc52ff7bc7296c4e47a7c886ee8cc7f2f438b9f49fe52a2661f42f3d/types-requests-2.27.31.tar.gz", hash = "sha256:6fab97b99fea52b9c7b466a4dd93e06bb325bc7e7420475e87831026a8dd35cc", size = 11492 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/30/9e11f0eadaa66d2d48195a4e69594e1acb1fe3c899da13c8986a9f097e5f/types_requests-2.27.31-py3-none-any.whl", hash = "sha256:1b6cf6a2bf57fd8018c1b636b69762900466fafddfb62e1330e092f3d4b0966a", size = 12224 },
+]
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/de/b9d7a68ad39092368fb21dd6194b362b98a1daeea5dcfef5e1adb5031c7e/types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f", size = 11239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e", size = 15377 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/3e/b00a62db91a83fff600de219b6ea9908e6918664899a2d85db222f4fbf19/typing_extensions-4.13.0.tar.gz", hash = "sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b", size = 106520 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/86/39b65d676ec5732de17b7e3c476e45bb80ec64eb50737a8dce1a4178aba1/typing_extensions-4.13.0-py3-none-any.whl", hash = "sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5", size = 45683 },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338 },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
+]
+
+[[package]]
+name = "zipp"
+version = "3.20.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29", size = 24199 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350", size = 9200 },
+]
+
+[[package]]
+name = "zipp"
+version = "3.21.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/50/bad581df71744867e9468ebd0bcd6505de3b275e06f202c2cb016e3ff56f/zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4", size = 24545 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/1a/7e4798e9339adc931158c9d69ecc34f5e6791489d469f5e50ec15e35f458/zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931", size = 9630 },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -281,6 +281,7 @@ test = [
 typing = [
     { name = "mypy", version = "1.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "mypy", version = "1.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest" },
     { name = "types-pyyaml", version = "6.0.12.20241230", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "types-pyyaml", version = "6.0.12.20250326", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "types-requests" },
@@ -300,6 +301,7 @@ requires-dist = [
     { name = "myst-parser", marker = "extra == 'docslive'", specifier = ">=3.0.1,<5.0.0" },
     { name = "packaging", specifier = ">=22,<23" },
     { name = "pytest", marker = "python_full_version >= '3.7' and python_full_version < '3.13' and extra == 'test'", specifier = ">=7.2.0,<8.0.0" },
+    { name = "pytest", marker = "extra == 'typing'", specifier = ">=7.4.4" },
     { name = "pytest-click", marker = "extra == 'test'", specifier = "~=1.1.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=2.12" },
     { name = "pytest-explicit", marker = "extra == 'test'", specifier = "~=1.0.1" },


### PR DESCRIPTION
- add code comments on cicd Pipeline
- build: migrate pyproject.toml and lock to uv format
- build: enable poetry-core (aka masonry) as build-backend
- test: verify 'uv' and 'build module' frontends integration with poetry build backend
- emphemeral: make both 'uv'/'-m build' build --sdist compatible with build-backend include/exclude control for Distro build
- docs: update docs and add Dependencies Dev Notes page
- restructure tox.ini envs
- ci: deactivate test.yaml on push to migrate-to-uv branch
- ci: add ci.yml offering "Quick CI Feedback" on pushes (with exception for main, dev, release branches)
- ci: use --no-emit-flag uv flag to mirror poetry export behavior
- build: use hybrid pyproject blueprint; pass 'uv sdist File Structure' Testsgit add -p
- test: fix isort/black test on Biskotaki Gold snapshot
- build: allow 'pip install' to link entrypoint scripts git add pyproject.toml -p
- remove empty lines
- test: update tests, and apply aggressive black
- tests: update Biskotaki interactive snapshot to match non-intractive snapshot
- build: do uv.lock and commit lock file
- build: add build in test uv optional dependencies
- clean code
- tests: refactor
- tests: clean code
- ci: do not run tests marked as slow on CI Pipeline
- test: add unit tests for dics builder mapping
- ci: update CI Pipeline
- ci: better integration testing on CI Pipeline
- ci: fix
- ci: speed-up CI Pipeline with parallel Jobs for "unit" and "integration" tests
- ci: emphemeral: speed-up CI Pipeline by 'building env' only once! using CI Artifacts
- ci: probably pytest-xdist and running build module do not play along
- ci: isolate flaky tests
- test: reorganize functions"
- ci: adopt uv for env builds!
- ci: add Static Code Analysis reusable workflow and call it in CI Pipeline
- enable job
- ci: deactivate build job and build envs inside each unit/integration test Jobs: try to compare speed with previous builds
- ci: restore prod integration test settings
- ci: fix if conditions of sca job
- ci: fix sca-job
- ci: implement allow failure for sca-job.yml
- ci add sdist and wheel Test Ci Jobs
- ci: tes all_wheels building and test suite running
- ci: fix all_wheels Job
- test: skipping tests if no sources, better maintainability, WIP
- test: move data creation code to fixture from test
- test: make cookie context rendering tests invariant of sources availability
- test: make all tests invariant of tests running inside project or not
- ci: use pip wheels to for all_wheels Job
- ci fix type
- ci add test extras from pypi at runtime
- ci: add production settings to CI Pipeline
- ci: fix syntax quirks
- ci: fix syntax quirks
- build: migrate to uv the docslive deps extra
- update gitignore
- ci: migrate Test Job of test.yaml to uv
- ci: uv in CI/CD with reusable uv test matrix job
- reduce type checking errors
- refactor: src and test code to pass mypy
- build: install pytest in typing extra
- ci: clean code
- add trigger for 'pr to dev' to CI Pipe
- build: migrate the isort profile black
- refactor(isort): apply isort
- refactor(black): apply black
- lint tests wip
- refactor(isort): apply isort
- refactor(ruff): apply ruff
- refactor(black): apply black
- pass mypy
- ci: optimize ci.yml both for CI push events and 'PR to dev' events
- ci: exclude ci-redesign branch from test.yaml triggers
- update .gitignore
- test: update biskotakigold.cli expected rendered file
- ci: document Jobs triggers in code comments
- ci: emphemeral override some defaults of ci.yml trigger conditions
- pass string in matrix of ci.yml job
- ci: do not run slow tests because they depend on tox in matrix build test job
- use action to install uv oin windows for test matrix job of ci.yml
- install our package wheel in matrix test Job of ci.yml
- run 'installation command' in bash shell for windows CI ci.yml pipeline
- avoid a bug of 'uv run pytest' that installs a runtime built package even uninstalling it first if already installedgit add -p!
- prepare for iteratively debugin the ci.yml windows job test errors
- debug test_logging on windows ci.yml Job
- pass inconviently blocking env var required to "document windows bug", otherwise tests fail
- Revert "debug test_logging on windows ci.yml Job"
- revert ci.yml Job triggers to production code
- test: fix code to account for windows host
- Revert "revert ci.yml Job triggers to production code"
- debug context assertion with gold_standard case
- fix syntax on ci pytest invocation
- pass legacy flag PY_WHEEL required by test suite of running on windows host
- enable all patforms on ci.yml Job
- set to prod settings the ci.yml pipeline
