### PR TITLE
Mutants elimination and CWEs mitigation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,13 +116,13 @@ jobs:
   ## Unless override, default trigger is (only) on PR to dev
   sca:
     # Unless override, default trigger is (only) on PR to dev
-    if: always() || vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: vars.OV_SCA == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     uses: ./.github/workflows/sca-job.yml
     with:
       python_version: '3.10'
       allow_failure: ${{ github.event_name != 'pull_request' || github.base_ref != 'dev' }}
       force_styles: ${{ github.event_name == 'pull_request' && github.base_ref == 'dev' }}
-      bandit: '{"h": 1, "m": 2, "l": 4}'  # Automated Acceptance Criteria for Bandit
+      bandit: '{"h": "0", "m": "0", "l": "4"}'  # Automated Acceptance Criteria for Bandit
 
   # RUN INTEGRATION TESTS: slower due to automated installations involved via pip
   ## Unless override, default trigger is (only) on PR to dev
@@ -175,13 +175,13 @@ jobs:
   # CROSS PLATFORM TESTING: 15s on Ubuntu, 25 on mac, 35 on windows
   ## Unless override, default trigger is (only) on PR to dev
   sample_matrix_test:
-    if: vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: always() || vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ${{ matrix.platform }}
     # trigger if event is pr to dev
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [macos-latest, ubuntu-latest, windows-latest]
         # platform: [windows-latest]
         python-version: ['3.10']
     steps:
@@ -236,7 +236,7 @@ jobs:
             echo "[INFO] Activating virtual environment for Linux/MacOS"
             . .venv/bin/activate
           fi
-          pytest -ra --run-requires_uv --run-network_bound -vvs -k 'context_with_expected_values[gold_standard]'
+          pytest -ra --run-requires_uv --run-network_bound -vvs
 
 ## PYDEPS
 

--- a/.github/workflows/dev_pr_validation.yml
+++ b/.github/workflows/dev_pr_validation.yml
@@ -194,7 +194,7 @@ jobs:
       python_version: '3.10'
       allow_failure: ${{ github.event_name != 'pull_request' || github.base_ref != 'dev' }}
       force_styles: ${{ github.event_name == 'pull_request' && github.base_ref == 'dev' }}
-      bandit: '{"h": 1, "m": 2, "l": 4}'  # Automated Acceptance Criteria for Bandit
+      bandit: '{"h": "0", "m": "0", "l": "4"}'  # Automated Acceptance Criteria for Bandit
 
   # PYDEPS
   pydeps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -201,7 +201,7 @@ jobs:
       python_version: '3.10'
       allow_failure: false
       force_styles: true
-      bandit: '{"h": 1, "m": 2, "l": 4}'  # Automated Acceptance Criteria for Bandit
+      bandit: '{"h": "0", "m": "2", "l": "4"}'  # Automated Acceptance Criteria for Bandit
 
   ### DOCS BUILD/TEST - DOCUMENTATION SITE ###
   docs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,27 @@ explicit-only = [
 ]
 
 
+### BANDIT
+
+[tool.bandit]
+exclude_dirs = ["tests/data", "path/to/file"]
+tests = []
+skips = [
+    "B101",
+]
+
+
 
 [tool.isort]
 profile = 'black'
 lines_after_imports = 2
+
+
+
+### MUTATION TESTS ###
+[tool.mutmut]
+tests_dir = "tests/"
+runner = "python -m pytest -n auto"
+
+paths_to_mutate = "src/cookiecutter_python/utils.py"
+

--- a/scripts/lint-local.sh
+++ b/scripts/lint-local.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env sh
+
+# Run Linters and modify in place !
+
+set -e
+
+
+# find all .yml or .yaml files in template dir and verify valid yaml
+
+SEARCH_DIR='tests/data/snapshots/'
+
+
+echo DONE
+
+# V2 for any posix-compliant shell
+find "${SEARCH_DIR}" -type f \( -name "*.yml" -o -name "*.yaml" \) | while read yaml_file; do
+  if [ ! -f "$yaml_file" ]; then
+    echo "ERROR: $yaml_file does not exist"
+    exit 1
+  fi
+
+  # Check if the file is a valid YAML file
+  if ! yq eval '.' "$yaml_file" > /dev/null 2>&1; then
+    echo "ERROR: $yaml_file is not a valid YAML file"
+    exit 1
+  fi
+done
+
+
+# Require Clean Git Working Dir Status
+
+if [ -n "$(git status --porcelain -uno)" ]; then
+  echo "Git Working Directory is not clean!"
+  echo "Please commit or stash your changes before running this script."
+  exit 1
+fi
+
+LINT_EXCLUDE='tests/data/snapshots'
+LINT_ARGS="src tests scripts"
+
+uv venv .lint-env
+. .lint-env/bin/activate
+uv pip install 'isort>=5.12.0, <6.0.0' 'black>=23.3.0, <24.0.0' 'ruff' 'prospector[with_pyroma]'
+
+## APPLY ISORT ##
+echo "[INFO] Running Isort..."
+uv run --active isort --skip tests/data/snapshots \
+  --skip 'src/cookiecutter_python/{{ cookiecutter.project_slug }}/' \
+  ${LINT_ARGS}
+
+
+# if files changed (git diff), then add and commit
+if [ -n "$(git status --porcelain -uno)" ]; then
+  git add -u
+  git commit -m "refactor(isort): apply isort"
+fi
+
+## APPLY BLACK ##
+echo "[INFO] Running Black..."
+uv run --active black \
+  --skip-string-normalization \
+  --exclude tests/data/snapshots \
+  --extend-exclude 'src/cookiecutter_python/{{ cookiecutter.project_slug }}/' \
+  --config pyproject.toml \
+  ${LINT_ARGS}
+
+
+# if files changed (git diff), then add and commit
+if [ -n "$(git status --porcelain -uno)" ]; then
+  git add -u
+  git commit -m "refactor(black): apply black"
+fi
+
+## APPLY RUFF ##
+echo "[INFO] Running Ruff..."
+uv run --active ruff check --fix \
+  --extend-exclude 'src/cookiecutter_python/\{\{\ cookiecutter.project_slug\ \}\}' \
+  ${LINT_ARGS}
+
+# if files changed (git diff), then add and commit
+if [ -n "$(git status --porcelain -uno)" ]; then
+  git add -u
+  git commit -m "refactor(ruff): apply ruff"
+fi
+
+set +e
+
+uv run --active isort --check --skip tests/data/snapshots --skip 'src/cookiecutter_python/{{ cookiecutter.project_slug }}/' ${LINT_ARGS}
+uv run --active black --check --skip-string-normalization --exclude tests/data/snapshots --extend-exclude 'src/cookiecutter_python/{{ cookiecutter.project_slug }}/' --config pyproject.toml ${LINT_ARGS}
+uv run --active ruff check --extend-exclude 'src/cookiecutter_python/\{\{\ cookiecutter.project_slug\ \}\}' ${LINT_ARGS}
+
+uv run --active prospector src
+uv run --active prospector tests
+
+set -e
+
+echo
+echo " ---> Linters applied !!"
+echo
+echo "For Final Sanity, run:"
+echo
+# echo "tox -e isort && tox -e black && tox -e ruff && tox -e prospector && tox -e pin-deps -- -E typing && tox -e type"
+echo ". .lint-env/bin/activate && export LINT_EXCLUDE='tests/data/snapshots' && export LINT_ARGS='src tests scripts' && uv run --active isort --check --skip tests/data/snapshots --skip 'src/cookiecutter_python/{{ cookiecutter.project_slug }}/' ${LINT_ARGS} && uv run --active black --check --skip-string-normalization --exclude tests/data/snapshots --extend-exclude 'src/cookiecutter_python/{{ cookiecutter.project_slug }}/' --config pyproject.toml ${LINT_ARGS} && uv run --active ruff check --extend-exclude 'src/cookiecutter_python/\{\{\ cookiecutter.project_slug\ \}\}' ${LINT_ARGS} && uv run --active prospector src && uv run --active prospector tests"
+echo

--- a/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_build_creates_artifacts.py
+++ b/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_build_creates_artifacts.py
@@ -6,10 +6,9 @@ import pytest
 @pytest.mark.slow
 def test_running_build_creates_source_and_wheel_distros(
     test_root,
-    run_subprocess,
+    my_run_subprocess,
 ):
     """Build wheel of biskotaki-no-input Snapshot Project and run tox -e check."""
-    import subprocess
     from pathlib import Path
 
     # Load Snapshot
@@ -18,7 +17,7 @@ def test_running_build_creates_source_and_wheel_distros(
     assert snapshot_dir.is_dir()
 
     ## Programmatically run Build, with the entrypoint we suggest, for a Dev to run
-    res = run_subprocess(  # tox -e build
+    res = my_run_subprocess(  # tox -e build
         *[sys.executable, '-m', 'tox', '-r', '-vv', '-e', 'build'],
         cwd=snapshot_dir,
         check=False,  # prevent raising exception, so we can do clean up
@@ -81,11 +80,11 @@ def test_running_build_creates_source_and_wheel_distros(
 
     # Check that Code passes Metadata Checks out of the box
     # run `tox -e check` and make sure we first do clean up before throwing an error
-    res = subprocess.run(  # tox -e check
-        [sys.executable, '-m', 'tox', '-r', '-vv', '-e', 'check'],
+    res = my_run_subprocess(  # tox -e check
+        *[sys.executable, '-m', 'tox', '-r', '-vv', '-e', 'check'],
         cwd=snapshot_dir,
         check=False,  # prevent raising exception, so we can do clean up
-        # pass the PKG_VERSION env var with value '0.0.1'
+        shell=False,  # prevent execution of untrusted input
         env={
             # required by Check environment
             'PKG_VERSION': '0.0.1',
@@ -100,7 +99,7 @@ def test_running_build_creates_source_and_wheel_distros(
     shutil.rmtree(snapshot_dir / '.tox' / 'check')
 
     # Check that Code passes Metadata Checks out of the box
-    assert res.returncode == 0
+    assert res.exit_code == 0
 
     # TODO Improve by parsing the expected stdout from tox
     # we can see that Pyroma is expected to run against Source but no Wheel distros

--- a/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py
+++ b/tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_lint_passes.py
@@ -13,9 +13,8 @@ import pytest
         'biskotaki-gold-standard',
     ],
 )
-def test_running_lint_passes(snapshot_name, test_root):
+def test_running_lint_passes(snapshot_name, my_run_subprocess, test_root):
     """Verify Snapshot Project passes `tox -e lint` out of the box."""
-    import subprocess
     from pathlib import Path
 
     # LINT Biskotaki
@@ -25,10 +24,11 @@ def test_running_lint_passes(snapshot_name, test_root):
     assert snapshot_dir.is_dir()
 
     # Programmatically run Lint, with the entrypoint we suggest, for a Dev to run
-    res = subprocess.run(  # tox -e lint
-        [sys.executable, '-m', 'tox', '-r', '-vv', '-e', 'lint'],
+    res = my_run_subprocess(  # tox -e lint
+        *[sys.executable, '-m', 'tox', '-vv', '-e', 'lint'],
         cwd=snapshot_dir,
         check=False,  # prevent raising exception, so we can do clean up
+        shell=False,  # prevent execution of untrusted input
     )
 
     # SANITY verify .tox/lint exists, when using tox 3.x
@@ -40,7 +40,9 @@ def test_running_lint_passes(snapshot_name, test_root):
     shutil.rmtree(snapshot_dir / '.tox' / 'lint')
 
     # Check that Code passes Lint out of the box
-    assert res.returncode == 0
+    assert (
+        res.exit_code == 0
+    ), f"Failed to run `tox -e lint` for {snapshot_name}\nSTDOUT:\n{res.stdout}\nSTDERR:\n{res.stderr}"
 
 
 @pytest.mark.slow
@@ -53,9 +55,8 @@ def test_running_lint_passes(snapshot_name, test_root):
         'biskotaki-gold-standard',
     ],
 )
-def test_running_ruff_passes(snapshot_name, test_root):
+def test_running_ruff_passes(snapshot_name, my_run_subprocess, test_root):
     """Verify Snapshot Project passes `tox -e ruff` out of the box."""
-    import subprocess
     from pathlib import Path
 
     # Load Snapshot
@@ -64,21 +65,21 @@ def test_running_ruff_passes(snapshot_name, test_root):
     assert snapshot_dir.is_dir()
 
     # Programmatically run Lint, with the entrypoint we suggest, for a Dev to run
-    res = subprocess.run(  # tox -e ruff
-        [sys.executable, '-m', 'tox', '-r', '-vv', '-e', 'ruff'],
+    res = my_run_subprocess(  # tox -e ruff
+        *[sys.executable, '-m', 'tox', '-vv', '-e', 'ruff'],
         cwd=snapshot_dir,
         check=False,  # prevent raising exception, so we can do clean up
+        shell=False,  # prevent execution of untrusted input
     )
+    # SANITY verify .tox/ruff exists, when using tox 3.x
+    assert (
+        res.exit_code == 0
+    ), f"Failed to run `tox -e ruff` for {snapshot_name}\nSTDOUT:\n{res.stdout}\nSTDERR:\n{res.stderr}"
 
     if (snapshot_dir / '.tox' / 'ruff').exists():
         # Remove .tox/ruff folder, created by tox 3.x
         import shutil
 
         shutil.rmtree(snapshot_dir / '.tox' / 'ruff')
-
-    # SANITY verify .tox/ruff exists, when using tox 3.x
-    assert (
-        res.returncode == 0
-    ), f"Failed to run `tox -e ruff` for {snapshot_name}\nSTDOUT:\n{res.stdout.decode(encoding='utf-8')}\nSTDERR:\n{res.stderr.decode(encoding='utf-8')}"
 
     # VERIFIED that Generator emits python code that pass Ruff out of the box !!

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1204,3 +1204,67 @@ def assert_files_committed_if_flag_is_on(
             return
 
     return _assert_files_commited
+
+
+@pytest.fixture(scope="session")
+def my_run_subprocess():
+    import subprocess
+    import sys
+    import typing as t
+
+    class CLIResult:
+        def __init__(self, completed_process: subprocess.CompletedProcess):
+            self._exit_code = int(completed_process.returncode)
+            self._stdout = str(completed_process.stdout, encoding='utf-8')
+            self._stderr = str(completed_process.stderr, encoding='utf-8')
+
+        @property
+        def exit_code(self) -> int:
+            return self._exit_code
+
+        @property
+        def stdout(self) -> str:
+            return self._stdout
+
+        @property
+        def stderr(self) -> str:
+            return self._stderr
+
+    def python37_n_above_kwargs():
+        return dict(
+            capture_output=True,  # capture stdout and stderr separately
+            # cwd=project_directory,
+        )
+
+    def python36_n_below_kwargs():
+        return dict(
+            stdout=subprocess.PIPE,  # capture stdout and stderr separately
+            stderr=subprocess.PIPE,
+        )
+
+    subprocess_run_map = {
+        True: python36_n_below_kwargs,
+        False: python37_n_above_kwargs,
+    }
+
+    def get_callable(cli_args: t.List[str], **kwargs) -> t.Callable[[], CLIResult]:
+        def subprocess_run() -> CLIResult:
+            kwargs_dict = subprocess_run_map[sys.version_info < (3, 7)]()
+            completed_process = subprocess.run(  # pylint: disable=W1510
+                cli_args, **dict(dict(kwargs_dict, check=True, shell=False), **kwargs)
+            )
+            return CLIResult(completed_process)
+
+        return subprocess_run
+
+    def execute_command_in_subprocess(executable: str, *args, **kwargs):
+        """Run command with python subprocess, given optional runtime arguments.
+
+        Use kwargs to override subprocess flags, such as 'check'
+
+        Flag 'check' defaults to True.
+        """
+        execute_subprocess = get_callable([executable] + list(args), **kwargs)
+        return execute_subprocess()
+
+    return execute_command_in_subprocess

--- a/tests/test_docs_id_2_folder_mapping.py
+++ b/tests/test_docs_id_2_folder_mapping.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 import pytest
 
-from cookiecutter_python.backend.gen_docs_common import get_docs_gen_internal_config
-
 
 @pytest.fixture
 def mock_correct_proj_template_dir(tmp_path: Path) -> Path:
@@ -34,6 +32,8 @@ def mock_wrong_proj_template_dir(tmp_path: Path) -> Path:
 
 def test_get_docs_gen_internal_config_valid(mock_correct_proj_template_dir: Path):
     """Test that valid docs folders are correctly mapped."""
+    from cookiecutter_python.backend.gen_docs_common import get_docs_gen_internal_config
+
     with patch(
         "cookiecutter_python.backend.gen_docs_common.PROJ_TEMPLATE_DIR",
         mock_correct_proj_template_dir,
@@ -53,6 +53,8 @@ def test_get_docs_gen_internal_config_invalid_folder_name(
     mock_wrong_proj_template_dir: Path,
 ):
     """Test that invalid folder names raise a ValueError."""
+    from cookiecutter_python.backend.gen_docs_common import get_docs_gen_internal_config
+
     _invalid_folder = mock_wrong_proj_template_dir / "docs-invalid-folder"  # noqa: F841
     # invalid_folder.rename(mock_proj_template_dir / "docs_invalid")
     with patch(
@@ -72,6 +74,7 @@ def test_get_docs_gen_internal_config_empty_directory(tmp_path: Path):
     """Test that an empty directory raises an assertion error."""
     from cookiecutter_python.backend.gen_docs_common import (  # type: ignore[attr-defined]
         NoDocsTemplateFolderError,
+        get_docs_gen_internal_config,
     )
 
     with patch(

--- a/tests/test_load_util.py
+++ b/tests/test_load_util.py
@@ -1,0 +1,178 @@
+import typing as t
+
+import pytest
+
+
+# GIVEN the Interface and Implementations modules are placed "correctly"
+@pytest.fixture
+def interface_and_implementations_lib(scope='function'):
+    """
+
+    filesystem
+    # simple_interface.py
+    #   ├── __init__.py
+    #   ├── lib
+    #   │   ├── __init__.py
+    #   │   ├── implementation_1.py
+    #   │   └── implementation_2.py
+
+    """
+
+    # GIVEN an "interface" from which we seek the concrete implementations
+    INTERFACE_MODULE = """
+from abc import ABC, abstractmethod
+from software_patterns import SubclassRegistry
+
+
+class SimpleInterface(ABC):
+    @abstractmethod
+    def method(self):
+        raise NotImplementedError("Subclasses should implement this!")
+
+
+class ImplementationsRegistry(SubclassRegistry[SimpleInterface]):
+    pass
+
+
+class Simple(metaclass=ImplementationsRegistry):
+    pass
+
+"""
+
+    # GIVEN a "library" of 2 interface implementations (concrete classes)
+    MODULE_1 = """
+from ..simple_interface import Simple
+
+__all__ = ["Implementation1"]
+
+@Simple.register_as_subclass('implementation_1')
+class Implementation1(Simple):
+    def method(self):
+        return "Implementation1"
+"""
+
+    MODULE_2 = """
+from ..simple_interface import Simple
+
+__all__ = ["Implementation2"]
+
+@Simple.register_as_subclass('implementation_2')
+class Implementation2(Simple):
+    def method(self):
+        return "Implementation2"
+"""
+
+    # create temp dir at tests/data
+    import os
+    import sys
+    import tempfile
+    from pathlib import Path
+
+    # Create a temporary directory
+    temp_dir: str = tempfile.mkdtemp()
+
+    DISTRO_NAME = 'unit_test_python_package'
+    DISTRO = Path(temp_dir) / DISTRO_NAME
+
+    def modify_filesystem():
+        # Create the directory structure
+        os.makedirs(DISTRO, exist_ok=False)
+
+        (DISTRO / "__init__.py").touch()
+
+        (DISTRO / "simple_interface.py").write_text(INTERFACE_MODULE)
+
+        os.makedirs(DISTRO / "lib", exist_ok=False)
+
+        (DISTRO / "lib" / "__init__.py").touch()
+        (DISTRO / "lib" / "implementation_1.py").write_text(MODULE_1)
+        (DISTRO / "lib" / "implementation_2.py").write_text(MODULE_2)
+
+    modify_filesystem()
+
+    # Add the temp directory to sys.path
+    sys.path.insert(0, temp_dir)
+
+    yield DISTRO_NAME
+
+    # Clean up the temporary directory
+    # shutil.rmtree(temp_dir)
+    # sys.path.remove(temp_dir)
+
+
+@pytest.mark.parametrize(
+    'load_arg',
+    [
+        'Simple',
+        'SimpleInterface',
+        'AnyRandomClass',
+    ],
+)
+def test_calling_load_successfully_registers_implementations_in_factory(
+    load_arg: str,
+    interface_and_implementations_lib: str,
+):
+    from importlib import import_module
+    from pathlib import Path
+
+    # GIVEN the function that dynamically imports modules and modifies globals
+    from cookiecutter_python.utils import load
+
+    DISTRO_NAME: str = interface_and_implementations_lib
+
+    # import the Facility (Registry Metaclass) Module
+    simple_interface_module = import_module(
+        '.'.join((Path(DISTRO_NAME) / "simple_interface").parts)
+    )
+
+    if load_arg == 'AnyRandomClass':
+        # if passed as an extra effect the load returns the 2 class.__name__ from the implementations
+        interface = type('AnyRandomClass', (object,), {})
+    else:
+        from importlib import import_module
+        from pathlib import Path
+
+        interface = getattr(simple_interface_module, load_arg)
+
+    # WHEN 'load' is called
+    objects: t.List[str] = load(
+        interface, module='.'.join((Path(DISTRO_NAME) / "lib").parts)
+    )
+    # Sanity check (this is tested in the next test)
+    assert objects if load_arg == 'Simple' else objects == []
+
+    # THEN the Simple Factory is automatically loaded as intended
+    impl1 = simple_interface_module.Simple.create('implementation_1')
+    assert impl1.method() == "Implementation1"
+    impl2 = simple_interface_module.Simple.create('implementation_2')
+    assert impl2.method() == "Implementation2"
+
+
+def test_calling_load_with_input_arg_Simple(
+    interface_and_implementations_lib: str,
+):
+    from importlib import import_module
+    from pathlib import Path
+
+    # GIVEN the function that dynamically imports modules and modifies globals
+    from cookiecutter_python.utils import load
+
+    DISTRO_NAME: str = interface_and_implementations_lib
+
+    simple_interface_module = import_module(
+        '.'.join((Path(DISTRO_NAME) / "simple_interface").parts)
+    )
+    interface = simple_interface_module.Simple
+
+    # WHEN 'load' is called
+    objects: t.List[str] = load(
+        interface, module='.'.join((Path(DISTRO_NAME) / "lib").parts)
+    )
+
+    # THEN the function returns a list of classes that implement the interface
+    assert len(objects) == 2
+    assert all(isinstance(obj, type) for obj in objects)
+
+    # AND the classes are the expected ones
+    assert objects[0].__name__ == "Implementation1"
+    assert objects[1].__name__ == "Implementation2"

--- a/uv.lock
+++ b/uv.lock
@@ -231,7 +231,7 @@ wheels = [
 
 [[package]]
 name = "cookiecutter-python"
-version = "2.5.0"
+version = "2.5.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
- test: eliminate some mutants, by adding 4 Test cases for utils.load
- refactor: kill all mutants
- chore: add mutmut config in pyproject.toml
- test: avoid test discovery errors
- clean and lint code
- build: update uv lock to also store the PEP version '2.5.1.dev0'
- test: update sdist expectation and account for -rc, -dev sem vers
- fix mypy and windows ci due to mutant killing
- fix: properly convert to python module ion windows host
- security: eliminate high severity CWE from tests
- security: fix false positive bandit report
- security: eliminate 6 reports of CWE-78 in tests
- ci: fix sca Job Json acceptance bandit criteria
- test: fix sytanx error
- refactor(isort): apply isort
- refactor(black): apply black
- ci: fix bandit acceptance criteria json syntax
- test: fix relic code
- fix: try to solve windows bug
- ci: set CI Pipeline to debug mode
- debug: windows
- test: fix test code with os-agnostic module dotted path construction
- refactor: simplify a bit the utils.py
- test: filesystem agnostic implementation
- test: filesystem agnostic implementation
- enable ci
- refactor(black): apply black
- commit lint-local.sh script
