### PR TITLE
Release v2.5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
       installation_mode: 'edit'
       python_version: '3.10'
       platform: 'ubuntu-latest'
+      # pytest_args: '-k test_gold -ra --run-requires_uv --run-network_bound -vvs --cov --cov-report=term-missing --cov-report=html:test-edit/htmlcov --cov-context=test --cov-report=xml:coverage.test-edit.xml -n auto tests'
+
+  codecov:
+    needs: code
+    # allow both code success and fail (but not skip)
+    if: always() && contains(fromJSON('["success", "failure"]'), needs.code.result) && vars.OV_CODECOV != 'false'
+    uses: ./.github/workflows/codecov-job.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # Build PACKAGE SDist and run Test Suite against it
   sdist:  ## Unless override, default trigger 'always'
@@ -47,7 +56,7 @@ jobs:
   wheel:  ## Unless override, default trigger 'always'
     uses: ./.github/workflows/test-python.yml
     with:
-      default_trigger: true
+      default_trigger: false
       override: '${{ vars.OV_WHEEL }}'
       installation_mode: 'wheel'
       upload_distro: true
@@ -57,7 +66,8 @@ jobs:
   # BUILD ALL WHEELS and run Test Suite against them
   ## Unless override, default trigger 'always'
   all_wheels:
-    if: vars.OV_ALL_WHEELS != 'false'  # Unless override, default trigger 'always'
+    if: false
+    # if: vars.OV_ALL_WHEELS != 'false'  # Unless override, default trigger 'always'
     runs-on: ubuntu-latest
     env:
       module_name: cookiecutter_python
@@ -127,7 +137,7 @@ jobs:
   # RUN INTEGRATION TESTS: slower due to automated installations involved via pip
   ## Unless override, default trigger is (only) on PR to dev
   test_integration:
-    if: always() || vars.OV_TEST_INTEGRATION == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: vars.OV_TEST_INTEGRATION == 'true' || (vars.OV_SCA != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -175,7 +185,7 @@ jobs:
   # CROSS PLATFORM TESTING: 15s on Ubuntu, 25 on mac, 35 on windows
   ## Unless override, default trigger is (only) on PR to dev
   sample_matrix_test:
-    if: always() || vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: vars.OV_MATRIX_TEST == 'true' || (vars.OV_MATRIX_TEST != 'false' && github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ${{ matrix.platform }}
     # trigger if event is pr to dev
     strategy:
@@ -237,6 +247,7 @@ jobs:
             . .venv/bin/activate
           fi
           pytest -ra --run-requires_uv --run-network_bound -vvs
+
 
 ## PYDEPS
 

--- a/.github/workflows/codecov-job.yml
+++ b/.github/workflows/codecov-job.yml
@@ -1,0 +1,38 @@
+## Codecov Upload - Reusable Workflow ##
+
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get Codecov binary
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+
+      # DOWNLOAD XML FILES FROM ARTIFACTS
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: coverage
+          pattern: coverage-*
+          merge-multiple: true
+
+      - run: ls -R coverage
+
+      # UPLOAD XML FILES TO CODECOV
+      - name: Upload Coverage Reports to Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}  # this is "read" from inputs
+        run: |
+          for file in coverage/coverage*.xml; do
+            OS_NAME=$(echo $file | sed -E "s/coverage-(\w\+)-/\1/")
+            PY_VERSION=$(echo $file | sed -E "s/coverage-\w\+-(\d\.)\+/\1/")
+            ./codecov -f $file -e "OS=$OS_NAME,PYTHON=$PY_VERSION" --flags unittests --verbose
+            echo "[INFO] Sent to Codecov: $file !"
+          done

--- a/.github/workflows/dev_pr_validation.yml
+++ b/.github/workflows/dev_pr_validation.yml
@@ -187,6 +187,15 @@ jobs:
     outputs:
       PEP_VERSION: ${{ steps.build.outputs.PEP_VERSION }}
 
+  # CODECOV Upload of COVERAGE reports
+  codecov:
+    if: always() && contains(fromJSON('["success", "failure"]'), needs.cross_platform_tests.result)
+    needs: cross_platform_tests
+    uses: ./.github/workflows/codecov-job.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+
   # STATIC CODE ANALYSIS: mypy, ruff, isort, black, bandit, mccabe, prospector, etc
   sca:
     uses: ./.github/workflows/sca-job.yml
@@ -221,35 +230,6 @@ jobs:
       python_version: '3.11'
 
 
-  # CODECOV Upload of COVERAGE reports
-  codecov_coverage_host:
-    if: always() && github.event_name == 'pull_request' && github.base_ref == 'release'
-    runs-on: ubuntu-latest
-    needs: cross_platform_tests
-    steps:
-      - uses: actions/checkout@v4
-      - name: Get Codecov binary
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-
-      - name: Download All Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: coverage
-          pattern: coverage-*
-          merge-multiple: true
-
-      - run: ls -R coverage
-
-      - name: Upload Coverage Reports to Codecov
-        run: |
-          for file in coverage/coverage*.xml; do
-            OS_NAME=$(echo $file | sed -E "s/coverage-(\w\+)-/\1/")
-            PY_VERSION=$(echo $file | sed -E "s/coverage-\w\+-(\d\.)\+/\1/")
-            ./codecov -f $file -e "OS=$OS_NAME,PYTHON=$PY_VERSION" --flags unittests --verbose
-            echo "Sent to Codecov: $file !"
-          done
 
   ## DOCKER BUILD and PUBLISH ON DOCKERHUB ##
   # Ref Page: https://automated-workflows.readthedocs.io/en/main/ref_docker/

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -39,6 +39,14 @@ on:
         default: 'ubuntu-latest'
         description: "Platform to use for the job. Default is 'ubuntu-latest'"
         type: string
+
+      # Pytest Settings #
+      pytest_args:
+        required: false
+        description: "Arguments to pass to pytest. Pass value to override the default value"
+        type: string
+
+
 jobs:
   test:
     if: inputs.override == 'true' || (inputs.override != 'false' && inputs.default_trigger == true)
@@ -94,6 +102,9 @@ jobs:
 
           uv pip install --no-deps ${{ inputs.installation_mode == 'edit' && '-e .' || inputs.installation_mode == 'sdist' && 'dist/*.tar.gz' || inputs.installation_mode == 'wheel' && 'dist/*.whl' }}
 
+      - name: Compute Pytest default Arguments
+        id: pytest_args
+        run: echo DEFAULT_PYTEST_ARGS='-ra --run-requires_uv --run-network_bound -vvs --cov --cov-report=term-missing --cov-report=html:test-${{ inputs.installation_mode }}/htmlcov --cov-context=test --cov-report=xml:coverage.test-${{ inputs.installation_mode }}.xml -n auto tests' >> $GITHUB_OUTPUT
 
       #### Run Test Suite against the package and measure Coverage ####
       - name: Run Tests and measure Coverage
@@ -104,6 +115,7 @@ jobs:
           BUG_LOG_DEL_WIN: 'permission_error'  # required on Windows Job
           PY_WHEEL: 1 # required on Windows Job
           COVERAGE_FILE: '.coverage.${{ inputs.installation_mode }}'
+          PYTEST_ARGS: "${{ inputs.pytest_args || steps.pytest_args.outputs.DEFAULT_PYTEST_ARGS }}"
         run: |
           if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
             echo "[INFO] Activating virtual environment for Windows"
@@ -114,10 +126,7 @@ jobs:
             . .venv/bin/activate
           fi
 
-          pytest -ra --run-requires_uv --run-network_bound -vvs --cov --cov-report=term-missing \
-            --cov-report=html:test-${{ inputs.installation_mode }}/htmlcov --cov-context=test \
-            --cov-report=xml:coverage.test-${{ inputs.installation_mode }}.xml \
-            -n auto tests
+          pytest ${{ env.PYTEST_ARGS }}
 
       ## Code Coverage ## TODO; enable combine by moving each .coverage file to other dir to avoid override of subsequent coverage invocations with pytest
       - name: "Discover and Combine Coverage data into XML Reports"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -167,32 +167,11 @@ jobs:
       # artifact_name: 'dist'
 
   codecov_coverage_host:
-    runs-on: ubuntu-latest
     needs: test
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get Codecov binary
-      run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        chmod +x codecov
-
-    - name: Download All Artifacts
-      uses: actions/download-artifact@v4
-      with:
-        path: coverage
-        pattern: coverage-*
-        merge-multiple: true
-
-    - run: ls -R coverage
-
-    - name: Upload Coverage Reports to Codecov
-      run: |
-        for file in coverage/coverage*.xml; do
-          OS_NAME=$(echo $file | sed -E "s/coverage-(\w\+)-/\1/")
-          PY_VERSION=$(echo $file | sed -E "s/coverage-\w\+-(\d\.)\+/\1/")
-          ./codecov -f $file -e "OS=$OS_NAME,PYTHON=$PY_VERSION" --flags unittests --verbose
-          echo "Sent to Codecov: $file !"
-        done
+    if: always() && contains(fromJSON('["success", "failure"]'), needs.test.result)
+    uses: ./.github/workflows/codecov-job.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   ## STATIC CODE ANALYSIS: mypy, ruff, isort, black, bandit, mccabe, prospector, etc
   sca:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,18 @@ Changelog
 =========
 
 
+2.5.3 (2024-04-18)
+==================
+
+Initial goal was to simplify the tests.  
+In the process:
+
+- we did that
+- increased code coverage
+- fixed a bug with the -f flag when used with the same gen params and on the same output location folder
+- improved user experience on the cli.terminal with better messages
+
+
 2.5.2 (2024-04-14)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -312,9 +312,10 @@ Free/Libre and Open Source Software (FLOSS)
 .. Code Climate CI
 .. Code maintainability & Technical Debt
 
+
 .. |maintainability| image:: https://api.codeclimate.com/v1/badges/1d347d7dfaa134fd944e/maintainability
    :alt: Maintainability
-   :target: https://codeclimate.com/github/boromir674/cookiecutter-python-package/
+   :target: https://codeclimate.com/github/boromir674/cookiecutter-python-package/maintainability
 
 .. |tech-debt| image:: https://img.shields.io/codeclimate/tech-debt/boromir674/cookiecutter-python-package
     :alt: Code Climate technical debt

--- a/README.rst
+++ b/README.rst
@@ -275,9 +275,9 @@ Free/Libre and Open Source Software (FLOSS)
 
 .. Github Releases & Tags
 
-.. |commits_since_specific_tag_on_master| image:: https://img.shields.io/github/commits-since/boromir674/cookiecutter-python-package/v2.5.2/master?color=blue&logo=github
+.. |commits_since_specific_tag_on_master| image:: https://img.shields.io/github/commits-since/boromir674/cookiecutter-python-package/v2.5.3/master?color=blue&logo=github
     :alt: GitHub commits since tagged version (branch)
-    :target: https://github.com/boromir674/cookiecutter-python-package/compare/v2.5.2..master
+    :target: https://github.com/boromir674/cookiecutter-python-package/compare/v2.5.3..master
 
 .. |commits_since_latest_github_release| image:: https://img.shields.io/github/commits-since/boromir674/cookiecutter-python-package/latest?color=blue&logo=semver&sort=semver
     :alt: GitHub commits since latest release (by SemVer)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ copyright = '2022, Konstantinos Lampridis'
 author = 'Konstantinos Lampridis'
 
 # The full version, including alpha/beta/rc tags
-release = '2.5.2'
+release = '2.5.3'
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "poetry.core.masonry.api"
 name = "cookiecutter_python"
 ### ... ###
 
-version = "2.5.2"
+version = "2.5.3"
 description = "1-click Generator of Python Project, from Template with streamlined \"DevOps\" using a powerful CI/CD Pipeline."
 readme = "README.rst"
 license = "AGPL-3.0-only"
@@ -74,7 +74,7 @@ maintainers = [
 license = {text = "AGPL-3.0-only"}
 
 name = "cookiecutter_python"
-version = "2.5.2"
+version = "2.5.3"
 description = "1-click Generator of Python Project, from Template with streamlined \"DevOps\" using a powerful CI/CD Pipeline."
 readme = "README.rst"
 # keywords = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ docslive = [
 typing = [
     "types-requests~=2.27.26",
     "types-pyyaml<7.0.0.0,>=6.0.12.5",
-    "mypy>=1.0.0",
+    "mypy==1.2.0",
     "pytest>=7.4.4",
 ]
 

--- a/scripts/mypy.sh
+++ b/scripts/mypy.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+
+## Run Mypy against Code
+
+# Env Required: .lint-env
+
+set -e
+
+# if env notr found exit with error
+if [ ! -d .lint-env ]; then
+  echo "No .lint-env found, please run 'uv venv .lint-env' first"
+  exit 1
+fi
+
+
+# uv export --no-emit-project --no-dev --extra typing --frozen --format requirements-txt -o prod+type.txt
+
+# . .lint-env/bin/activate
+
+# uv pip install -r prod+type.txt
+
+# set mypy environment
+export MYPYPATH=${MYPYPATH:-src/stubs}
+
+# DRYness
+PKG=${PGK:-src/cookiecutter_python}
+
+mypy --show-error-codes --check-untyped-defs \
+    --exclude tests/data \
+    "${PKG}/hooks" \
+    "${PKG}/backend" "${PKG}/handle" \
+    "${PKG}/utils.py" "${PKG}/exceptions.py" \
+    "${PKG}/cli.py" "${PKG}/cli_handlers.py" \
+    "${PKG}/__main__.py" "${PKG}/__init__.py" \
+    tests

--- a/scripts/sphinx-process.sh
+++ b/scripts/sphinx-process.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+sphinx-build -E -b doctest docs docs-dist
+sphinx-build -E -b html docs docs-dist
+sphinx-build -b spelling docs docs-dist
+sphinx-build -b linkcheck docs docs-dist
+
+echo "View documentation at docs-dist/index.html; it is ready to be hosted!"

--- a/src/cookiecutter_python/__init__.py
+++ b/src/cookiecutter_python/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '2.5.2'
+__version__ = '2.5.3'
 
 from . import _logging  # noqa

--- a/src/cookiecutter_python/hooks/pre_gen_project.py
+++ b/src/cookiecutter_python/hooks/pre_gen_project.py
@@ -10,23 +10,28 @@ from cookiecutter_python.backend import sanitize
 logger = logging.getLogger(__name__)
 
 
-def get_request():
+# Minimizes the jinja-controlled python syntax-incopatible surface
+# Also, this makes static code analyzers to avoid issues with syntax errors
+# due to the templated (dynamically injected) code in this file
+def get_context() -> OrderedDict:
+    """Get the Context, that was used by the Templating Engine at render time"""
     # Templated Variables should be centralized here for easier inspection
-    # Also, this makes static code analyzers to avoid issues with syntax errors
-    # due to the templated (dynamically injected) code in this file
-    cookiecutter: OrderedDict = OrderedDict()
-    cookiecutter: OrderedDict = {{cookiecutter}}  # type:ignore[no-redef]
+    COOKIECUTTER: OrderedDict = OrderedDict()
+    COOKIECUTTER = {{cookiecutter}}  # type: ignore    # pylint: disable=undefined-variable  # noqa: F821
+    return COOKIECUTTER
+
+
+def get_request():
+    cookie_dict: OrderedDict = get_context()
 
     logger.info(
-        "Cookiecutter Data: %s", json.dumps(cookiecutter, sort_keys=True, indent=4)
+        "Cookiecutter Data: %s", json.dumps(cookie_dict, sort_keys=True, indent=4)
     )
 
-    interpreters = cookiecutter['interpreters']
-    if isinstance(interpreters, str):  # we assume it is json
-        interpreters = json.loads(interpreters)
-        cookiecutter['interpreters'] = interpreters
+    interpreters = cookie_dict['interpreters']
+
     # the name the client code should use to import the generated package/module
-    module_name = '{{ cookiecutter.pkg_name }}'
+    module_name: str = cookie_dict['pkg_name']
 
     return type(
         'PreGenProjectRequest',
@@ -34,7 +39,7 @@ def get_request():
         {
             'module_name': module_name,
             'pypi_package': module_name.replace('_', '-'),
-            'package_version_string': '{{ cookiecutter.version }}',
+            'package_version_string': cookie_dict['version'],
             'interpreters': interpreters['supported-interpreters'],
         },
     )
@@ -56,14 +61,13 @@ def input_sanitization(request):
 
     # CHECK Version
     try:
-        # verify_templated_semantic_version(request.package_version_string)
         sanitize['semantic-version'](request.package_version_string)
     except sanitize.exceptions['semantic-version'] as error:
         raise InputSanitizationError(
             f'ERROR: {request.package_version_string} is not a valid Semantic Version!'
         ) from error
+
     try:
-        # verify_input_interpreters(request.interpreters)
         sanitize['interpreters'](request.interpreters)
     except sanitize.exceptions['interpreters'] as error:
         logger.warning(

--- a/src/stubs/git/__init__.pyi
+++ b/src/stubs/git/__init__.pyi
@@ -1,7 +1,20 @@
+import os
 import typing as t
 
 class Repo:
     def __init__(self, folder_path: str, **kwargs: t.Any) -> None: ...
+    @classmethod
+    def init(
+        cls,
+        path: t.Union[t.Union[str, "os.PathLike[str]"], None] = None,
+        mkdir: bool = True,
+        # odbt: t.Type[GitCmdObjectDB] = GitCmdObjectDB,
+        expand_vars: bool = True,
+        **kwargs: t.Any,
+    ) -> "Repo": ...
+    def is_dirty(self, **kwargs: t.Any) -> bool: ...
+    @property
+    def git(self) -> t.Any: ...
 
 class Actor:
     def __init__(self, name: str, email: str) -> None: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,232 +116,6 @@ def project_dir(generate_project, distro_loc, tmpdir):
     return proj_dir
 
 
-## NEW REQUEST FACTORY
-
-
-class EmulatedRequest(t.Protocol):
-    project_dir: t.Union[str, None]
-    cookiecutter: t.Optional[t.Dict]
-    author: t.Optional[str]
-    author_email: t.Optional[str]
-    initialize_git_repo: t.Optional[bool]
-    interpreters: t.Optional[t.Dict]
-    project_type: t.Optional[str]
-    module_name: t.Optional[str]
-    cicd: t.Optional[str]
-
-
-class EmulatedRequestFactory(t.Protocol):
-    def pre(**kwargs: t.Any) -> EmulatedRequest:
-        ...
-
-    def post(**kwargs: t.Any) -> EmulatedRequest:
-        ...
-
-
-@pytest.fixture
-def request_factory(distro_loc) -> t.Type[EmulatedRequestFactory]:
-    """Emulate the templated data used in the 'pre' and 'post' hooks scripts.
-
-    MUST be kept in SYNC with the 'pre' and 'post' hook scripts, and their
-    interface.
-
-    Before and after the actual generation process (ie read the termplate files,
-    generate the output files, etc), there 2 scripts that run. The 'pre' script
-    (implemented as src/cookiecutter/hooks/pre_gen_project.py) and the 'post'
-    script (implemented as src/cookiecutter/hooks/post_gen_project.py) run
-    before and after the generation process respectively.
-
-    These scripts are also templated! Consequently, similarly to the how the
-    templated package depends on the 'templated variables', the 'pre' and 'post'
-    scripts need a 'templating engine'.
-
-    In our unit tests we do not run a 'templating engine' and thus it is
-    required to mock the templated variables, when testing the 'pre' or 'post'
-    script.
-
-    This fixture provides an easily modified/extended infrastructure to mock all
-    the necessary 'template variables' mentioned above.
-
-    Thus, when writing (unit) test cases for testing code in the 'pre' or 'post'
-    scripts (python modules) it is recommended to use this fixture to mock any
-    'templated variables', according to your needs.
-
-    Tip:
-        Templated variables typically appear in double curly braces:
-        ie {{ ... }}).
-        If the 'code under test' depends on any 'template variable', (ie if you
-        see code inside double curly braces), such as for example the common
-        '{{ cookiecutter }}', then it is recommended to use this fixture to mock
-        any required 'templated variable'.
-
-    Returns:
-        [type]: [description]
-    """
-    import json
-    from collections import OrderedDict
-
-    from software_patterns import SubclassRegistry
-
-    # Read JSON data from 'tests/data/test_cookiecutter.json'
-    # The JSON schema and values MUST reflect a valid internal state of the
-    # Generator's Template Engine.
-    # at the moment, we exclusively use cookiecutter (and jinja2) for templating
-    # GIVEN data that reflect a state, which the Templating Engine is possible
-    # to arrive at, when the Generator CLI is invoked.
-    ### We want to skip running the templating engine, so we mock the state
-    ### that the templating engine would have produced.
-    engine_state: OrderedDict = json.loads(
-        (Path(my_dir) / 'data' / 'test_cookiecutter.json').read_text(),
-        object_pairs_hook=OrderedDict,
-    )
-
-    # THEN the state must be a valid Context for the Template Engine
-    assert set(engine_state.keys()) == {'cookiecutter'}
-    intended_template_path: str = engine_state['cookiecutter'].pop('_template')
-    assert intended_template_path == '.'
-
-    assert '_template' not in engine_state['cookiecutter'].keys()
-
-    # GIVEN the Generator's Templated Variables Configuration file (ie cookiecutter.json)
-    # which is used at runtime, when the Generator CLI is invoked, and thus if
-    # file changes, the Generator's behaviour changes.
-    td_cookiecutter_json_data = json.loads(
-        (distro_loc / 'cookiecutter.json').read_text(), object_pairs_hook=OrderedDict
-    )
-
-    # ΤΗΕΝ engine_state (excluding _template) must be supported TD cookiecutter.json
-    intended_templated_variables: t.Set[str] = set(engine_state['cookiecutter'].keys())
-    supported_template_variables: t.Set[str] = set(td_cookiecutter_json_data.keys())
-    engine_state_vars_supported_by_td: bool = intended_templated_variables.issubset(
-        supported_template_variables
-    )
-    assert engine_state_vars_supported_by_td
-
-    # WHEN we define a way to create a valid input for pre and post hooks
-
-    @attr.s(auto_attribs=True, kw_only=True)
-    class EmulatedHookRequest:
-        """Hook Request Data Class.
-
-        This class is used to mock the 'templated variables' that are used in
-        the 'pre' and 'post' scripts.
-
-        The 'pre' and 'post' scripts are also templated! Consequently, similarly
-        to the how the templated package depends on the 'templated variables',
-        the 'pre' and 'post' scripts need a 'templating engine'.
-
-        In our unit tests we do not run a 'templating engine' and thus it is
-        required to mock the templated variables, when testing the 'pre' or
-        'post' script.
-
-        This class provides an easily modified/extended infrastructure to mock
-        all the necessary 'template variables' mentioned above.
-
-        Thus, when writing (unit) test cases for testing code in the 'pre' or
-        'post' scripts (python modules) it is recommended to use this class to
-        mock any 'templated variables', according to your needs.
-
-        Args:
-            project_dir (t.Optional[str]): [description]
-            cookiecutter (t.Optional[t.Dict]): [description]
-            author (t.Optional[str]): [description]
-            author_email (t.Optional[str]): [description]
-            initialize_git_repo (t.Optional[bool]): [description]
-            interpreters (t.Optional[t.Dict]): [description]
-            project_type (t.Optional[str]): [description]
-            module_name (t.Optional[str]): [description]
-            cicd (t.Optional[str]): [description]
-        """
-
-        project_dir: t.Optional[str]
-        # TODO improvement: add key/value types
-        ### We want to skip running the templating engine, so we mock the state
-        ### that the templating engine would have produced.
-
-        # Templated Vars (cookiecutter) use in Context for Jinja Rendering
-        vars: t.Dict[str, t.Any] = attr.ib(
-            # IMPORTANT: emulates jinja context vars (ie from list of choices to 1st choice)
-            default=OrderedDict(
-                td_cookiecutter_json_data, **engine_state['cookiecutter']
-            )
-        )
-        initialize_git_repo: t.Optional[bool] = attr.ib(default=True)
-        interpreters: t.Optional[t.List[str]] = attr.ib(
-            default=[
-                '3.6',
-                '3.7',
-                '3.8',
-                '3.9',
-                '3.10',
-                '3.11',
-            ]
-        )
-        project_type: t.Optional[str] = attr.ib(default='module')
-        module_name: t.Optional[str] = attr.ib(default='awesome_novelty_python_library')
-        pypi_package: t.Optional[str] = attr.ib(
-            default=attr.Factory(
-                lambda self: self.module_name.replace('_', '-'), takes_self=True
-            )
-        )
-        package_version_string: t.Optional[str] = attr.ib(default='0.0.1')
-        docs_extra_info: t.Optional[t.Dict[str, str]] = attr.ib(
-            default=dict(
-                **{'mkdocs': 'docs-mkdocs', 'sphinx': 'docs-sphinx'},
-            )
-        )
-        docs_website: t.Optional[t.Dict[str, str]] = attr.ib(
-            default={
-                'builder': 'sphinx',
-                'python_runtime': '3.10',
-            }
-        )
-        cicd: t.Optional[str] = attr.ib(default='stable')
-
-        # add entries to this to fix tests/test_post_hook.py after prod code advances
-        def __attrs_post_init__(self):
-            """IMPORTANT: emulate jinja context vars (ie from list of choices to 1st choice)"""
-            # self.vars is available at Generator runtime.
-            # so populate values here to allow control per test case
-            self.vars['project_type'] = self.project_type
-            self.vars['cicd'] = self.cicd
-
-    class HookRequestFacility(SubclassRegistry[EmulatedHookRequest]):
-        pass
-
-    class HookRequest(metaclass=HookRequestFacility):
-        pass
-
-    @attr.s(auto_attribs=True, kw_only=True)
-    @HookRequest.register_as_subclass('pre')
-    class PreGenProjectRequest(EmulatedHookRequest):
-        project_dir: str = attr.ib(default=None)
-
-    @HookRequest.register_as_subclass('post')
-    class PostGenProjectRequest(EmulatedHookRequest):
-        pass
-
-    # Adapting exposed interface
-    def get_create_request_func(type_id: str) -> t.Callable[..., EmulatedHookRequest]:
-        def _create_request(**kwargs):
-            ret: EmulatedHookRequest = HookRequest.create(type_id, **kwargs)
-            return ret
-
-        return _create_request
-
-    return type(
-        'RequestFactory',
-        (),
-        {
-            'pre': get_create_request_func('pre'),
-            'post': get_create_request_func('post'),
-        },
-    )
-
-
-### END
-
-
 @pytest.fixture
 def mock_hosting_services(future_session_mock):
     """Mock the FuturesSession class given urls and http status codes.
@@ -1206,6 +980,9 @@ def assert_files_committed_if_flag_is_on(
     return _assert_files_commited
 
 
+# Proper SUBPROCESS wrapper
+
+
 @pytest.fixture(scope="session")
 def my_run_subprocess():
     import subprocess
@@ -1268,3 +1045,46 @@ def my_run_subprocess():
         return execute_subprocess()
 
     return execute_command_in_subprocess
+
+
+@pytest.fixture
+def dat(distro_loc: Path):
+    import json
+    from collections import OrderedDict
+
+    my_dir = Path(__file__).resolve().parent
+
+    # Read JSON data from 'tests/data/test_cookiecutter.json'
+    # The JSON schema and values MUST reflect a valid internal state of the
+    # Generator's Template Engine.
+    # at the moment, we exclusively use cookiecutter (and jinja2) for templating
+    # GIVEN data that reflect a state, which the Templating Engine is possible
+    # to arrive at, when the Generator CLI is invoked.
+    ### We want to skip running the templating engine, so we mock the state
+    ### that the templating engine would have produced.
+    engine_state: OrderedDict = json.loads(
+        (my_dir / 'data' / 'test_cookiecutter.json').read_text(),
+        object_pairs_hook=OrderedDict,
+    )
+
+    # THEN the state must be a valid Context for the Template Engine
+    assert set(engine_state.keys()) == {'cookiecutter'}
+    intended_template_path: str = engine_state['cookiecutter'].pop('_template')
+    assert intended_template_path == '.'
+
+    assert '_template' not in engine_state['cookiecutter'].keys()
+
+    # GIVEN the Generator's Templated Variables Configuration file (ie cookiecutter.json)
+    # which is used at runtime, when the Generator CLI is invoked, and thus if
+    # file changes, the Generator's behaviour changes.
+    td_cookiecutter_json_data = json.loads(
+        (distro_loc / 'cookiecutter.json').read_text(), object_pairs_hook=OrderedDict
+    )
+
+    # ΤΗΕΝ engine_state (excluding _template) must be supported TD cookiecutter.json
+    state_keys = set(engine_state['cookiecutter'].keys())
+    assert state_keys and state_keys.issubset(set(td_cookiecutter_json_data.keys()))
+
+    # Templated Vars (cookiecutter) use in Context for Jinja Rendering
+
+    return OrderedDict(td_cookiecutter_json_data, **engine_state['cookiecutter'])

--- a/tests/data/test_cookiecutter.json
+++ b/tests/data/test_cookiecutter.json
@@ -2,6 +2,7 @@
   "cookiecutter": {
     "project_name": "Pytest Object Getter",
     "project_slug": "pytest-object-getter",
+    "project_type": "module",
     "repo_name": "pytest-object-getter",
     "pkg_name": "pytest_object_getter",
     "full_name": "Konstantinos Lampridis",
@@ -16,12 +17,16 @@
     "initialize_git_repo": "yes",
     "interpreters": {
       "supported-interpreters": [
-        "py38",
-        "py39"
+        "3.6",
+        "3.7",
+        "3.8",
+        "3.9",
+        "3.10",
+        "3.11"
       ]
     },
-    "docs_builder": ["mkdocs", "sphinx"],
-    "rtd_python_version": ["3.8", "3.9", "3.10", "3.11", "3.12"],
+    "docs_builder": "sphinx",
+    "rtd_python_version": "3.10",
     "cicd": "stable",
     "_template": "."
   }

--- a/tests/test_build_backend_sdist.py
+++ b/tests/test_build_backend_sdist.py
@@ -147,6 +147,9 @@ def sdist_expected_correct_file_structure():
         # 'src/stubs/requests_futures/sessions.pyi',
     )
     TESTS = (
+        'tests/test_git_sdk.py',
+        'tests/test_git_porcelain.py',
+        'tests/test_is_repo_clean_function.py',
         'tests/biskotaki_ci/conftest.py',
         'tests/test_load_util.py',
         'tests/biskotaki_ci/snapshot/biskotaki_ci_no_input/test_build_creates_artifacts.py',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,22 +137,6 @@ def test_cli_offline(
 
     project_dir: str = path.abspath(path.join(gen_proj_dir, config.project_slug))
 
-    # our code introduced WARNING logs due to git commit from issued to GEnerator
-    # assert config.data['initialize_git_repo'] is True and path.exists(
-    #     path.join(project_dir, 'cookie-py.log')
-    # )
-
-    # assert config.data['initialize_git_repo'] is False and not path.exists(
-    #     path.join(project_dir, 'cookie-py.log')
-    # )
-
-    # assert config.data['initialize_git_repo'] is False or path.exists(
-    #     path.join(project_dir, 'cookie-py.log')
-    # ), f"Gen Logs NOT Found in Gen Target Dir! File Contents as string:\n\n{open(path.join(project_dir, 'cookie-py.log')).read()}"
-
-    # assert cookie-py.log is not found in project_dir
-    # assert not path.exists(path.join(project_dir, 'cookie-py.log')), f"Gen Logs Found in Gen Target Dir! File Contents as string:\n\n{open(path.join(project_dir, 'cookie-py.log')).read()}"
-
     assert_files_committed_if_flag_is_on(gen_proj_dir, config)
 
     # Assert Files found at runtime in Generated Project Root Dir are the expected ones

--- a/tests/test_git_porcelain.py
+++ b/tests/test_git_porcelain.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+
+import pytest
+
+
+def test_git_status_porcelain_subprocess_fails_with_check_equals_false(
+    my_run_subprocess, tmp_path: Path
+):
+    """Test that git status --porcelain returns an error when not in a git directory."""
+    # GIVEN a directory that is NOT a git repository
+    non_git_folder = (tmp_path / 'non_git_dir').resolve().absolute()
+    non_git_folder.mkdir()
+
+    # WHEN running git status --porcelain
+    result = my_run_subprocess(
+        'git',
+        *['status', '--porcelain'],
+        cwd=str(non_git_folder),
+        check=False,  # prevent raising exception
+    )
+    # THEN the command should return an error
+    assert result.stdout == ''
+    assert 'fatal: not a git repository' in result.stderr
+    assert result.exit_code != 0
+
+
+def test_git_status_porcelain_subprocess_fails_with_check_equals_true(
+    my_run_subprocess, tmp_path: Path
+):
+    """Test that git status --porcelain raises an exception when not in a git directory."""
+    # GIVEN a directory that is NOT a git repository
+    non_git_folder = (tmp_path / 'non_git_dir').resolve().absolute()
+    non_git_folder.mkdir()
+
+    # WHEN running git status --porcelain
+    from subprocess import CalledProcessError
+
+    with pytest.raises(
+        CalledProcessError,
+        match=r"Command '\['git', 'status', '--porcelain'\]' returned non-zero exit status 128.",
+    ):
+        _ = my_run_subprocess(
+            'git',
+            *['status', '--porcelain'],
+            cwd=str(non_git_folder),
+            check=True,
+        )
+
+
+def test_git_porcelain_after_git_init(tmp_path: Path):
+    # GIVEN a directory with one file inside
+    git_folder = (tmp_path / 'non_git_dir').resolve().absolute()
+    git_folder.mkdir()
+
+    # place one a.txt file inside
+    (git_folder / 'a.txt').touch()
+
+    # GIVEN it is initialized as a git repository
+    from git import Repo
+
+    repo = Repo.init(f"{git_folder}")
+    assert (git_folder / '.git').exists()
+    assert (git_folder / '.git').is_dir()
+
+    # WHEN running git status --porcelain
+    result = repo.git.status(porcelain=True)
+
+    # THEN the command should return an empty string
+    assert result == '?? a.txt'
+    assert repo.is_dirty() is False
+
+
+def test_git_porcelain_after_git_init_with_subprocess(my_run_subprocess, tmp_path):
+    # GIVEN a directory with one file inside
+    git_folder: Path = (tmp_path / 'non_git_dir').resolve().absolute()
+    git_folder.mkdir()
+
+    # place one a.txt file inside
+    (git_folder / 'a.txt').touch()
+
+    # GIVEN it is initialized as a git repository
+    result = my_run_subprocess(
+        'git',
+        *['init'],
+        cwd=str(git_folder),
+        check=True,  # prevent raising exception
+    )
+    assert (git_folder / '.git').exists()
+    assert (git_folder / '.git').is_dir()
+
+    result = my_run_subprocess(
+        'git',
+        *['status', '--porcelain'],
+        cwd=str(git_folder),
+        check=False,  # prevent raising exception
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout == '?? a.txt\n'
+    assert result.stderr == ''
+
+
+def test_git_porcelain_after_git_init_with_subprocess_v2(my_run_subprocess, tmp_path):
+    # GIVEN a directory with one file inside
+    git_folder: Path = (tmp_path / 'non_git_dir').resolve().absolute()
+    git_folder.mkdir()
+
+    # place one a.txt file inside
+    (git_folder / 'a.txt').touch()
+
+    # GIVEN it is initialized as a git repository
+    from git import Repo
+
+    _ = Repo.init(f"{git_folder}")
+    assert (git_folder / '.git').exists()
+    assert (git_folder / '.git').is_dir()
+
+    result = my_run_subprocess(
+        'git',
+        *['status', '--porcelain'],
+        cwd=str(git_folder),
+        check=False,  # prevent raising exception
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout == '?? a.txt\n'
+    assert result.stderr == ''

--- a/tests/test_git_sdk.py
+++ b/tests/test_git_sdk.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+
+def test_git_sdk_init(tmp_path: Path):
+    from git import Repo
+
+    # GIVEN a temporary empty folder
+    project_folder = tmp_path / "unit_test_git_sdk_init"
+    project_folder.mkdir(parents=True, exist_ok=True)
+    # sanity that no files exist
+    assert not any(project_folder.iterdir())
+    # WHEN we call the git_sdk_init function
+    _ = Repo.init(project_folder)
+    # THEN a .git folder should be created
+    assert (project_folder / ".git").exists()
+
+
+def test_git_sdk_is_dirty(tmp_path: Path):
+    from git import Repo
+
+    # GIVEN a temporary empty folder
+    project_folder = tmp_path / "unit_test_git_sdk_is_dirty"
+    project_folder.mkdir(parents=True, exist_ok=True)
+    # sanity that no files exist
+    assert not any(project_folder.iterdir())
+    # WHEN we call the git_sdk_init function
+    repo = Repo.init(project_folder)
+    # THEN a .git folder should be created
+    assert (project_folder / ".git").exists()
+    print("\n" + str(project_folder))
+    # WHEN we create a new file
+    new_file = project_folder / "test_file.txt"
+    new_file.write_text("Hello World!")
+
+    # WHEN we check if the repo is dirty
+    assert not repo.is_dirty()
+
+    # cw = repo.config_writer()
+
+    # # Access the global configuration writer
+    # WARNING THIS destroys the format of .gitconfig and remove comments !!!!
+    # with repo.config_writer(config_level='global') as cw:
+    #     # Add the safe.directory entry
+    #     cw.add_value('safe', 'directory', str(project_folder))
+
+    # cr = repo.config_reader()  # use reader to assert writer effect

--- a/tests/test_gold_standard.py
+++ b/tests/test_gold_standard.py
@@ -46,6 +46,16 @@ def gen_gs_project(
     assert gen_project_dir.exists()
     assert gen_project_dir.is_dir()
     assert (gen_project_dir / 'src').exists() and (gen_project_dir / 'src').is_dir()
+    # Ad-hoc sanity checks that docs folder contains all sub-dirs and nested files
+    assert (gen_project_dir / 'docs').exists()
+    assert not (gen_project_dir / 'docs-mkdocs').exists()
+    assert not (gen_project_dir / 'docs-sphinx').exists()
+    assert (gen_project_dir / 'docs').is_dir()
+    assert (gen_project_dir / 'docs' / 'assets').exists()
+    assert (gen_project_dir / 'docs' / 'assets').is_dir()
+    assert (gen_project_dir / 'docs' / 'dev_guides').exists()
+    assert (gen_project_dir / 'docs' / 'dev_guides' / 'docker.md').exists()
+    assert (gen_project_dir / 'docs' / 'dev_guides' / 'docker.md').is_file()
 
     ## Logging file created - Assertions ##
     from cookiecutter_python._logging_config import FILE_TARGET_LOGS

--- a/tests/test_is_repo_clean_function.py
+++ b/tests/test_is_repo_clean_function.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+def test_is_git_repo_clean_returns_true_for_new_repo(my_run_subprocess, tmp_path: Path):
+    # GIVEN a directory with one file inside
+    git_folder = (tmp_path / 'non_git_dir').resolve().absolute()
+    git_folder.mkdir()
+    (git_folder / 'a.txt').touch()
+
+    # GIVEN it is initialized as a git repository
+    from git import Repo
+
+    repo = Repo.init(f"{git_folder}")
+    assert (git_folder / '.git').exists()
+    assert (git_folder / '.git').is_dir()
+
+    result = my_run_subprocess(
+        'git',
+        *['status', '--porcelain'],
+        cwd=str(git_folder),
+        check=False,  # prevent raising exception
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout == '?? a.txt\n'
+    assert result.stderr == ''
+
+    # WHEN calling is_git_repo_clean function
+    repo_is_clean = not repo.is_dirty()
+
+    # THEN the command should return True
+    assert repo_is_clean is True

--- a/tests/test_load_util.py
+++ b/tests/test_load_util.py
@@ -4,8 +4,8 @@ import pytest
 
 
 # GIVEN the Interface and Implementations modules are placed "correctly"
-@pytest.fixture
-def interface_and_implementations_lib(scope='function'):
+@pytest.fixture(scope='function')
+def interface_and_implementations_lib():
     """
 
     filesystem
@@ -125,6 +125,7 @@ def test_calling_load_successfully_registers_implementations_in_factory(
         '.'.join((Path(DISTRO_NAME) / "simple_interface").parts)
     )
 
+    interface: t.Type
     if load_arg == 'AnyRandomClass':
         # if passed as an extra effect the load returns the 2 class.__name__ from the implementations
         interface = type('AnyRandomClass', (object,), {})
@@ -135,7 +136,7 @@ def test_calling_load_successfully_registers_implementations_in_factory(
         interface = getattr(simple_interface_module, load_arg)
 
     # WHEN 'load' is called
-    objects: t.List[str] = load(
+    objects: t.List[t.Type] = load(
         interface, module='.'.join((Path(DISTRO_NAME) / "lib").parts)
     )
     # Sanity check (this is tested in the next test)
@@ -165,9 +166,7 @@ def test_calling_load_with_input_arg_Simple(
     interface = simple_interface_module.Simple
 
     # WHEN 'load' is called
-    objects: t.List[str] = load(
-        interface, module='.'.join((Path(DISTRO_NAME) / "lib").parts)
-    )
+    objects = load(interface, module='.'.join((Path(DISTRO_NAME) / "lib").parts))
 
     # THEN the function returns a list of classes that implement the interface
     assert len(objects) == 2

--- a/tests/test_post_gen_hook_regression.py
+++ b/tests/test_post_gen_hook_regression.py
@@ -1,8 +1,8 @@
 # verify that post_gen_hook knows the docs builder initial docs location
-# this will make sure the PostGenProject hook can the necessary file removals
-# and replacements for Docs. If Gneration docs features get update, but ie we forget to
+# this will make sure the PostGenProject hook can do the necessary file removals
+# and replacements for Docs. If Generator's "docs features" get update, but ie we forget to
 # update the post_gen_hook, this test will fail and remind us to update the hook
-# Regressoin Test, if you will
+# so this is a Regression Test, if you will
 def test_post_gen_hook_docs_builder_initial_docs_location():
     # GIVEN a callback to retrieve the 'docs internal config' (dic), as computed by post_gen_hook
     from cookiecutter_python.hooks.post_gen_project import DOCS

--- a/uv.lock
+++ b/uv.lock
@@ -231,7 +231,7 @@ wheels = [
 
 [[package]]
 name = "cookiecutter-python"
-version = "2.5.1.dev0"
+version = "2.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
@@ -279,8 +279,7 @@ test = [
     { name = "pytest-xdist" },
 ]
 typing = [
-    { name = "mypy", version = "1.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "mypy", version = "1.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "mypy" },
     { name = "pytest" },
     { name = "types-pyyaml", version = "6.0.12.20241230", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "types-pyyaml", version = "6.0.12.20250326", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -296,7 +295,7 @@ requires-dist = [
     { name = "gitpython", marker = "python_full_version >= '3.7' and python_full_version < '3.13'", specifier = ">=3.1.30,<4.0.0" },
     { name = "jinja2-time", specifier = ">=0.2.0,<1.0.0" },
     { name = "markdown-it-py", marker = "python_full_version >= '3.8' and python_full_version < '3.13' and extra == 'docs'", specifier = "==3.0.0" },
-    { name = "mypy", marker = "extra == 'typing'", specifier = ">=1.0.0" },
+    { name = "mypy", marker = "extra == 'typing'", specifier = "==1.2.0" },
     { name = "myst-parser", marker = "python_full_version >= '3.10' and python_full_version < '3.13' and extra == 'docs'", specifier = ">=3.0.0,<4.0.0" },
     { name = "myst-parser", marker = "extra == 'docslive'", specifier = ">=3.0.1,<5.0.0" },
     { name = "packaging", specifier = ">=22,<23" },
@@ -753,92 +752,36 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.14.1"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
 dependencies = [
-    { name = "mypy-extensions", marker = "python_full_version < '3.9'" },
-    { name = "tomli", marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.9'" },
+    { name = "mypy-extensions" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/eb/2c92d8ea1e684440f54fa49ac5d9a5f19967b7b472a281f419e69a8d228e/mypy-1.14.1.tar.gz", hash = "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6", size = 3216051 }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/d0/d96d26e7a6f5a2ed4add8c649f30bce26fc413f25a6ecc5d93ab22c270e1/mypy-1.2.0.tar.gz", hash = "sha256:f70a40410d774ae23fcb4afbbeca652905a04de7948eaf0b1789c8d1426b72d1", size = 2804931 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/7a/87ae2adb31d68402da6da1e5f30c07ea6063e9f09b5e7cfc9dfa44075e74/mypy-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:52686e37cf13d559f668aa398dd7ddf1f92c5d613e4f8cb262be2fb4fedb0fcb", size = 11211002 },
-    { url = "https://files.pythonhosted.org/packages/e1/23/eada4c38608b444618a132be0d199b280049ded278b24cbb9d3fc59658e4/mypy-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1fb545ca340537d4b45d3eecdb3def05e913299ca72c290326be19b3804b39c0", size = 10358400 },
-    { url = "https://files.pythonhosted.org/packages/43/c9/d6785c6f66241c62fd2992b05057f404237deaad1566545e9f144ced07f5/mypy-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90716d8b2d1f4cd503309788e51366f07c56635a3309b0f6a32547eaaa36a64d", size = 12095172 },
-    { url = "https://files.pythonhosted.org/packages/c3/62/daa7e787770c83c52ce2aaf1a111eae5893de9e004743f51bfcad9e487ec/mypy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ae753f5c9fef278bcf12e1a564351764f2a6da579d4a81347e1d5a15819997b", size = 12828732 },
-    { url = "https://files.pythonhosted.org/packages/1b/a2/5fb18318a3637f29f16f4e41340b795da14f4751ef4f51c99ff39ab62e52/mypy-1.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0fe0f5feaafcb04505bcf439e991c6d8f1bf8b15f12b05feeed96e9e7bf1427", size = 13012197 },
-    { url = "https://files.pythonhosted.org/packages/28/99/e153ce39105d164b5f02c06c35c7ba958aaff50a2babba7d080988b03fe7/mypy-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:7d54bd85b925e501c555a3227f3ec0cfc54ee8b6930bd6141ec872d1c572f81f", size = 9780836 },
-    { url = "https://files.pythonhosted.org/packages/da/11/a9422850fd506edbcdc7f6090682ecceaf1f87b9dd847f9df79942da8506/mypy-1.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f995e511de847791c3b11ed90084a7a0aafdc074ab88c5a9711622fe4751138c", size = 11120432 },
-    { url = "https://files.pythonhosted.org/packages/b6/9e/47e450fd39078d9c02d620545b2cb37993a8a8bdf7db3652ace2f80521ca/mypy-1.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d64169ec3b8461311f8ce2fd2eb5d33e2d0f2c7b49116259c51d0d96edee48d1", size = 10279515 },
-    { url = "https://files.pythonhosted.org/packages/01/b5/6c8d33bd0f851a7692a8bfe4ee75eb82b6983a3cf39e5e32a5d2a723f0c1/mypy-1.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba24549de7b89b6381b91fbc068d798192b1b5201987070319889e93038967a8", size = 12025791 },
-    { url = "https://files.pythonhosted.org/packages/f0/4c/e10e2c46ea37cab5c471d0ddaaa9a434dc1d28650078ac1b56c2d7b9b2e4/mypy-1.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:183cf0a45457d28ff9d758730cd0210419ac27d4d3f285beda038c9083363b1f", size = 12749203 },
-    { url = "https://files.pythonhosted.org/packages/88/55/beacb0c69beab2153a0f57671ec07861d27d735a0faff135a494cd4f5020/mypy-1.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f2a0ecc86378f45347f586e4163d1769dd81c5a223d577fe351f26b179e148b1", size = 12885900 },
-    { url = "https://files.pythonhosted.org/packages/a2/75/8c93ff7f315c4d086a2dfcde02f713004357d70a163eddb6c56a6a5eff40/mypy-1.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:ad3301ebebec9e8ee7135d8e3109ca76c23752bac1e717bc84cd3836b4bf3eae", size = 9777869 },
-    { url = "https://files.pythonhosted.org/packages/43/1b/b38c079609bb4627905b74fc6a49849835acf68547ac33d8ceb707de5f52/mypy-1.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30ff5ef8519bbc2e18b3b54521ec319513a26f1bba19a7582e7b1f58a6e69f14", size = 11266668 },
-    { url = "https://files.pythonhosted.org/packages/6b/75/2ed0d2964c1ffc9971c729f7a544e9cd34b2cdabbe2d11afd148d7838aa2/mypy-1.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cb9f255c18052343c70234907e2e532bc7e55a62565d64536dbc7706a20b78b9", size = 10254060 },
-    { url = "https://files.pythonhosted.org/packages/a1/5f/7b8051552d4da3c51bbe8fcafffd76a6823779101a2b198d80886cd8f08e/mypy-1.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b4e3413e0bddea671012b063e27591b953d653209e7a4fa5e48759cda77ca11", size = 11933167 },
-    { url = "https://files.pythonhosted.org/packages/04/90/f53971d3ac39d8b68bbaab9a4c6c58c8caa4d5fd3d587d16f5927eeeabe1/mypy-1.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:553c293b1fbdebb6c3c4030589dab9fafb6dfa768995a453d8a5d3b23784af2e", size = 12864341 },
-    { url = "https://files.pythonhosted.org/packages/03/d2/8bc0aeaaf2e88c977db41583559319f1821c069e943ada2701e86d0430b7/mypy-1.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fad79bfe3b65fe6a1efaed97b445c3d37f7be9fdc348bdb2d7cac75579607c89", size = 12972991 },
-    { url = "https://files.pythonhosted.org/packages/6f/17/07815114b903b49b0f2cf7499f1c130e5aa459411596668267535fe9243c/mypy-1.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:8fa2220e54d2946e94ab6dbb3ba0a992795bd68b16dc852db33028df2b00191b", size = 9879016 },
-    { url = "https://files.pythonhosted.org/packages/39/02/1817328c1372be57c16148ce7d2bfcfa4a796bedaed897381b1aad9b267c/mypy-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7084fb8f1128c76cd9cf68fe5971b37072598e7c31b2f9f95586b65c741a9d31", size = 11143050 },
-    { url = "https://files.pythonhosted.org/packages/b9/07/99db9a95ece5e58eee1dd87ca456a7e7b5ced6798fd78182c59c35a7587b/mypy-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8f845a00b4f420f693f870eaee5f3e2692fa84cc8514496114649cfa8fd5e2c6", size = 10321087 },
-    { url = "https://files.pythonhosted.org/packages/9a/eb/85ea6086227b84bce79b3baf7f465b4732e0785830726ce4a51528173b71/mypy-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44bf464499f0e3a2d14d58b54674dee25c031703b2ffc35064bd0df2e0fac319", size = 12066766 },
-    { url = "https://files.pythonhosted.org/packages/4b/bb/f01bebf76811475d66359c259eabe40766d2f8ac8b8250d4e224bb6df379/mypy-1.14.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99f27732c0b7dc847adb21c9d47ce57eb48fa33a17bc6d7d5c5e9f9e7ae5bac", size = 12787111 },
-    { url = "https://files.pythonhosted.org/packages/2f/c9/84837ff891edcb6dcc3c27d85ea52aab0c4a34740ff5f0ccc0eb87c56139/mypy-1.14.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:bce23c7377b43602baa0bd22ea3265c49b9ff0b76eb315d6c34721af4cdf1d9b", size = 12974331 },
-    { url = "https://files.pythonhosted.org/packages/84/5f/901e18464e6a13f8949b4909535be3fa7f823291b8ab4e4b36cfe57d6769/mypy-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:8edc07eeade7ebc771ff9cf6b211b9a7d93687ff892150cb5692e4f4272b0837", size = 9763210 },
-    { url = "https://files.pythonhosted.org/packages/ca/1f/186d133ae2514633f8558e78cd658070ba686c0e9275c5a5c24a1e1f0d67/mypy-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3888a1816d69f7ab92092f785a462944b3ca16d7c470d564165fe703b0970c35", size = 11200493 },
-    { url = "https://files.pythonhosted.org/packages/af/fc/4842485d034e38a4646cccd1369f6b1ccd7bc86989c52770d75d719a9941/mypy-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46c756a444117c43ee984bd055db99e498bc613a70bbbc120272bd13ca579fbc", size = 10357702 },
-    { url = "https://files.pythonhosted.org/packages/b4/e6/457b83f2d701e23869cfec013a48a12638f75b9d37612a9ddf99072c1051/mypy-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27fc248022907e72abfd8e22ab1f10e903915ff69961174784a3900a8cba9ad9", size = 12091104 },
-    { url = "https://files.pythonhosted.org/packages/f1/bf/76a569158db678fee59f4fd30b8e7a0d75bcbaeef49edd882a0d63af6d66/mypy-1.14.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:499d6a72fb7e5de92218db961f1a66d5f11783f9ae549d214617edab5d4dbdbb", size = 12830167 },
-    { url = "https://files.pythonhosted.org/packages/43/bc/0bc6b694b3103de9fed61867f1c8bd33336b913d16831431e7cb48ef1c92/mypy-1.14.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:57961db9795eb566dc1d1b4e9139ebc4c6b0cb6e7254ecde69d1552bf7613f60", size = 13013834 },
-    { url = "https://files.pythonhosted.org/packages/b0/79/5f5ec47849b6df1e6943d5fd8e6632fbfc04b4fd4acfa5a5a9535d11b4e2/mypy-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:07ba89fdcc9451f2ebb02853deb6aaaa3d2239a236669a63ab3801bbf923ef5c", size = 9781231 },
-    { url = "https://files.pythonhosted.org/packages/a0/b5/32dd67b69a16d088e533962e5044e51004176a9952419de0370cdaead0f8/mypy-1.14.1-py3-none-any.whl", hash = "sha256:b66a60cc4073aeb8ae00057f9c1f64d49e90f918fbcef9a977eb121da8b8f1d1", size = 2752905 },
-]
-
-[[package]]
-name = "mypy"
-version = "1.15.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version == '3.10.*'",
-    "python_full_version == '3.9.*'",
-]
-dependencies = [
-    { name = "mypy-extensions", marker = "python_full_version >= '3.9'" },
-    { name = "tomli", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/43/d5e49a86afa64bd3839ea0d5b9c7103487007d728e1293f52525d6d5486a/mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43", size = 3239717 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/f8/65a7ce8d0e09b6329ad0c8d40330d100ea343bd4dd04c4f8ae26462d0a17/mypy-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:979e4e1a006511dacf628e36fadfecbcc0160a8af6ca7dad2f5025529e082c13", size = 10738433 },
-    { url = "https://files.pythonhosted.org/packages/b4/95/9c0ecb8eacfe048583706249439ff52105b3f552ea9c4024166c03224270/mypy-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c4bb0e1bd29f7d34efcccd71cf733580191e9a264a2202b0239da95984c5b559", size = 9861472 },
-    { url = "https://files.pythonhosted.org/packages/84/09/9ec95e982e282e20c0d5407bc65031dfd0f0f8ecc66b69538296e06fcbee/mypy-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be68172e9fd9ad8fb876c6389f16d1c1b5f100ffa779f77b1fb2176fcc9ab95b", size = 11611424 },
-    { url = "https://files.pythonhosted.org/packages/78/13/f7d14e55865036a1e6a0a69580c240f43bc1f37407fe9235c0d4ef25ffb0/mypy-1.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7be1e46525adfa0d97681432ee9fcd61a3964c2446795714699a998d193f1a3", size = 12365450 },
-    { url = "https://files.pythonhosted.org/packages/48/e1/301a73852d40c241e915ac6d7bcd7fedd47d519246db2d7b86b9d7e7a0cb/mypy-1.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2e2c2e6d3593f6451b18588848e66260ff62ccca522dd231cd4dd59b0160668b", size = 12551765 },
-    { url = "https://files.pythonhosted.org/packages/77/ba/c37bc323ae5fe7f3f15a28e06ab012cd0b7552886118943e90b15af31195/mypy-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:6983aae8b2f653e098edb77f893f7b6aca69f6cffb19b2cc7443f23cce5f4828", size = 9274701 },
-    { url = "https://files.pythonhosted.org/packages/03/bc/f6339726c627bd7ca1ce0fa56c9ae2d0144604a319e0e339bdadafbbb599/mypy-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2922d42e16d6de288022e5ca321cd0618b238cfc5570e0263e5ba0a77dbef56f", size = 10662338 },
-    { url = "https://files.pythonhosted.org/packages/e2/90/8dcf506ca1a09b0d17555cc00cd69aee402c203911410136cd716559efe7/mypy-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ee2d57e01a7c35de00f4634ba1bbf015185b219e4dc5909e281016df43f5ee5", size = 9787540 },
-    { url = "https://files.pythonhosted.org/packages/05/05/a10f9479681e5da09ef2f9426f650d7b550d4bafbef683b69aad1ba87457/mypy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973500e0774b85d9689715feeffcc980193086551110fd678ebe1f4342fb7c5e", size = 11538051 },
-    { url = "https://files.pythonhosted.org/packages/e9/9a/1f7d18b30edd57441a6411fcbc0c6869448d1a4bacbaee60656ac0fc29c8/mypy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a95fb17c13e29d2d5195869262f8125dfdb5c134dc8d9a9d0aecf7525b10c2c", size = 12286751 },
-    { url = "https://files.pythonhosted.org/packages/72/af/19ff499b6f1dafcaf56f9881f7a965ac2f474f69f6f618b5175b044299f5/mypy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1905f494bfd7d85a23a88c5d97840888a7bd516545fc5aaedff0267e0bb54e2f", size = 12421783 },
-    { url = "https://files.pythonhosted.org/packages/96/39/11b57431a1f686c1aed54bf794870efe0f6aeca11aca281a0bd87a5ad42c/mypy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c9817fa23833ff189db061e6d2eff49b2f3b6ed9856b4a0a73046e41932d744f", size = 9265618 },
-    { url = "https://files.pythonhosted.org/packages/98/3a/03c74331c5eb8bd025734e04c9840532226775c47a2c39b56a0c8d4f128d/mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd", size = 10793981 },
-    { url = "https://files.pythonhosted.org/packages/f0/1a/41759b18f2cfd568848a37c89030aeb03534411eef981df621d8fad08a1d/mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f", size = 9749175 },
-    { url = "https://files.pythonhosted.org/packages/12/7e/873481abf1ef112c582db832740f4c11b2bfa510e829d6da29b0ab8c3f9c/mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464", size = 11455675 },
-    { url = "https://files.pythonhosted.org/packages/b3/d0/92ae4cde706923a2d3f2d6c39629134063ff64b9dedca9c1388363da072d/mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee", size = 12410020 },
-    { url = "https://files.pythonhosted.org/packages/46/8b/df49974b337cce35f828ba6fda228152d6db45fed4c86ba56ffe442434fd/mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e", size = 12498582 },
-    { url = "https://files.pythonhosted.org/packages/13/50/da5203fcf6c53044a0b699939f31075c45ae8a4cadf538a9069b165c1050/mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22", size = 9366614 },
-    { url = "https://files.pythonhosted.org/packages/5a/fa/79cf41a55b682794abe71372151dbbf856e3008f6767057229e6649d294a/mypy-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e601a7fa172c2131bff456bb3ee08a88360760d0d2f8cbd7a75a65497e2df078", size = 10737129 },
-    { url = "https://files.pythonhosted.org/packages/d3/33/dd8feb2597d648de29e3da0a8bf4e1afbda472964d2a4a0052203a6f3594/mypy-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:712e962a6357634fef20412699a3655c610110e01cdaa6180acec7fc9f8513ba", size = 9856335 },
-    { url = "https://files.pythonhosted.org/packages/e4/b5/74508959c1b06b96674b364ffeb7ae5802646b32929b7701fc6b18447592/mypy-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f95579473af29ab73a10bada2f9722856792a36ec5af5399b653aa28360290a5", size = 11611935 },
-    { url = "https://files.pythonhosted.org/packages/6c/53/da61b9d9973efcd6507183fdad96606996191657fe79701b2c818714d573/mypy-1.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f8722560a14cde92fdb1e31597760dc35f9f5524cce17836c0d22841830fd5b", size = 12365827 },
-    { url = "https://files.pythonhosted.org/packages/c1/72/965bd9ee89540c79a25778cc080c7e6ef40aa1eeac4d52cec7eae6eb5228/mypy-1.15.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1fbb8da62dc352133d7d7ca90ed2fb0e9d42bb1a32724c287d3c76c58cbaa9c2", size = 12541924 },
-    { url = "https://files.pythonhosted.org/packages/46/d0/f41645c2eb263e6c77ada7d76f894c580c9ddb20d77f0c24d34273a4dab2/mypy-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:d10d994b41fb3497719bbf866f227b3489048ea4bbbb5015357db306249f7980", size = 9271176 },
-    { url = "https://files.pythonhosted.org/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e", size = 2221777 },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/eceab134d307042fc7b4aef3d7e285c1afbb306bf49388ab2c3e2330aaa1/mypy-1.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:701189408b460a2ff42b984e6bd45c3f41f0ac9f5f58b8873bbedc511900086d", size = 10681662 },
+    { url = "https://files.pythonhosted.org/packages/17/81/62fb78abb9ae22a5eabf9d5b81b6b7ba89d65b9b190e10c685e4367183eb/mypy-1.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fe91be1c51c90e2afe6827601ca14353bbf3953f343c2129fa1e247d55fd95ba", size = 9743024 },
+    { url = "https://files.pythonhosted.org/packages/c2/73/3a01b56227d33e62cbb78065099c94f9fa811fe21759ee263245a3dbcc6f/mypy-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d26b513225ffd3eacece727f4387bdce6469192ef029ca9dd469940158bc89e", size = 12194451 },
+    { url = "https://files.pythonhosted.org/packages/fa/ee/9f56e9b54a3624d95d9b39682e1169089fafbcc3cbbef18f42198dd47abb/mypy-1.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3a2d219775a120581a0ae8ca392b31f238d452729adbcb6892fa89688cb8306a", size = 12267498 },
+    { url = "https://files.pythonhosted.org/packages/e2/05/e6a96713cdd2f84964d78b390cb347255cf167dfb867add23230fe5e6696/mypy-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:2e93a8a553e0394b26c4ca683923b85a69f7ccdc0139e6acd1354cc884fe0128", size = 8933169 },
+    { url = "https://files.pythonhosted.org/packages/7b/36/5d90979fa86bcf5862186f540b9925538d0e5239049d7bb1d9ee3ca0f77a/mypy-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3efde4af6f2d3ccf58ae825495dbb8d74abd6d176ee686ce2ab19bd025273f41", size = 10560737 },
+    { url = "https://files.pythonhosted.org/packages/1d/db/f0b4b1d7b6604806d14a5ee5a5f0ac03d6b81d4d6d134a191dfb3da9cb86/mypy-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:695c45cea7e8abb6f088a34a6034b1d273122e5530aeebb9c09626cea6dca4cb", size = 9646187 },
+    { url = "https://files.pythonhosted.org/packages/5b/50/b5ecf349e2bfc4fe31fb974457470d19d099d59daa92a9ff0f0e38bbfbe2/mypy-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0e9464a0af6715852267bf29c9553e4555b61f5904a4fc538547a4d67617937", size = 12079419 },
+    { url = "https://files.pythonhosted.org/packages/54/2b/4605b4197d169f22453b55eb48cc6d3237ddf3167c24398497148bfef99f/mypy-1.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8293a216e902ac12779eb7a08f2bc39ec6c878d7c6025aa59464e0c4c16f7eb9", size = 12158234 },
+    { url = "https://files.pythonhosted.org/packages/24/69/795b82e3fba8e50e265dac3d387616706babd1ac23eeed3943bd8d074cc6/mypy-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:f46af8d162f3d470d8ffc997aaf7a269996d205f9d746124a179d3abe05ac602", size = 8928840 },
+    { url = "https://files.pythonhosted.org/packages/9e/be/3ed7aaaa6e7961f3150120514ef34cfa3398259258019f91c7619bda3801/mypy-1.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a197ad3a774f8e74f21e428f0de7f60ad26a8d23437b69638aac2764d1e06a6a", size = 10620205 },
+    { url = "https://files.pythonhosted.org/packages/26/ce/88417b791de919ffad917e32a37772e4595877141f68fc47d4833ccad66c/mypy-1.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c9a084bce1061e55cdc0493a2ad890375af359c766b8ac311ac8120d3a472950", size = 9705044 },
+    { url = "https://files.pythonhosted.org/packages/66/41/f437110f2d7af95a547d4b7d37953448dbebf751b39becdf472eb444c327/mypy-1.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaeaa0888b7f3ccb7bcd40b50497ca30923dba14f385bde4af78fac713d6d6f6", size = 12151539 },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/cc9051ba981c3f41146afde7a58c26d264d95e59f19bce10bb24ae6c6c43/mypy-1.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bea55fc25b96c53affab852ad94bf111a3083bc1d8b0c76a61dd101d8a388cf5", size = 12217894 },
+    { url = "https://files.pythonhosted.org/packages/f6/30/f86b31edb4c7c81f63e9cb27a28a2f9e7aa1a58188ded12f96936c391b10/mypy-1.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:4c8d8c6b80aa4a1689f2a179d31d86ae1367ea4a12855cc13aa3ba24bb36b2d8", size = 8915637 },
+    { url = "https://files.pythonhosted.org/packages/cb/58/8dd346e4e0fa889ccf5d523926d3c1ca50035805731adfc8258e8db67bc5/mypy-1.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:70894c5345bea98321a2fe84df35f43ee7bb0feec117a71420c60459fc3e1eed", size = 10677881 },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/17cb4c29225aa677a2b8efd0e524a5ee369dbd2857f928d8cc104dc33720/mypy-1.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4a99fe1768925e4a139aace8f3fb66db3576ee1c30b9c0f70f744ead7e329c9f", size = 9741925 },
+    { url = "https://files.pythonhosted.org/packages/3d/42/abf8568dbbe9e207ac90d650164aac43ed9c40fbae0d5f87d842d62ec485/mypy-1.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:023fe9e618182ca6317ae89833ba422c411469156b690fde6a315ad10695a521", size = 12190233 },
+    { url = "https://files.pythonhosted.org/packages/81/6f/9a2af7cc16f9929addbdcb30509ef561edfbcfde5efe886fa7a0dac5eb9d/mypy-1.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4d19f1a239d59f10fdc31263d48b7937c585810288376671eaf75380b074f238", size = 12267013 },
+    { url = "https://files.pythonhosted.org/packages/1d/1a/8166959cf10a56218cf7a8eabd23d101050e38159ffee1868dd3e3a90ab1/mypy-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:2de7babe398cb7a85ac7f1fd5c42f396c215ab3eff731b4d761d68d0f6a80f48", size = 8936806 },
+    { url = "https://files.pythonhosted.org/packages/3b/e2/e191616ecd88ba45e9e662f0b87b390c76dd56affe8d18cffa44bf7ba91c/mypy-1.2.0-py3-none-any.whl", hash = "sha256:d8e9187bfcd5ffedbe87403195e1fc340189a68463903c39e2b63307c9fa0394", size = 2397780 },
 ]
 
 [[package]]


### PR DESCRIPTION

Initial goal was to simplify the tests.  
In the process:

- we did that
- increased code coverage
- fixed a bug with the -f flag when used with the same gen params and on the same output location folder
- improved user experience on the cli.terminal with better messages

### Changes

- add tests for git porcelain and is_repo_clean function
- pass mypy on source and test code
- start tracking stripts
- test: retire request_factory fixture and simplify conceptualization
- test: add git sdk sanity tests
- refactor: add better error handling during post gen hook process
- fix: passing the -f flag now works with the same config and output location
- ci: configure ci pipeline for testing
- ci: allow receiving dynamic pytest args in test-python.yml Workflow
- fixup! ci: configure ci pipeline for testing
- ci: call Codecov Upload workflow from ci.yml
- ci: run only test_gold on ci
- ci: wire-up CODECOV_TOKEN secret
- ci: run prodution tests
- docs: better url for maintainability badge
- ci: call codecov-job.yml in test.yaml and dev_pr_validation.yml
- refactor: lint and typecheck
